### PR TITLE
[R4R] {feature}: add BVM_ETH mint on op-geth

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
+
 	"golang.org/x/crypto/sha3"
 )
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -355,9 +355,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if ethValue := st.msg.ETHValue; ethValue != nil && ethValue.Cmp(big.NewInt(0)) != 0 {
 		st.addBVMETHBalance(ethValue)
 		st.addBVMETHTotalSupply(ethValue)
-		st.generateMintEvent(*st.msg.To, ethValue)
-		//st.state.AddLog()
-		//types.Log{}
+		st.generateBVMETHMintEvent(*st.msg.To, ethValue)
 	}
 	snap := st.state.Snapshot()
 
@@ -540,21 +538,21 @@ func (st *StateTransition) gasUsed() uint64 {
 }
 
 func (st *StateTransition) addBVMETHBalance(ethValue *big.Int) {
-	BVM_ETH := common.HexToAddress(BVM_ETH_ADDR)
+	bvmEth := common.HexToAddress(BVM_ETH_ADDR)
 	key := getBVMETHBalanceKey(*st.msg.To)
-	value := st.state.GetState(BVM_ETH, key)
+	value := st.state.GetState(bvmEth, key)
 	bal := value.Big()
 	bal = bal.Add(bal, ethValue)
-	st.state.SetState(BVM_ETH, key, common.BigToHash(bal))
+	st.state.SetState(bvmEth, key, common.BigToHash(bal))
 }
 
 func (st *StateTransition) addBVMETHTotalSupply(ethValue *big.Int) {
-	BVM_ETH := common.HexToAddress(BVM_ETH_ADDR)
+	bvmEth := common.HexToAddress(BVM_ETH_ADDR)
 	key := getBVMETHTotalSupplyKey()
-	value := st.state.GetState(BVM_ETH, key)
+	value := st.state.GetState(bvmEth, key)
 	bal := value.Big()
 	bal = bal.Add(bal, ethValue)
-	st.state.SetState(BVM_ETH, key, common.BigToHash(bal))
+	st.state.SetState(bvmEth, key, common.BigToHash(bal))
 }
 
 func getBVMETHBalanceKey(addr common.Address) common.Hash {
@@ -567,14 +565,10 @@ func getBVMETHBalanceKey(addr common.Address) common.Hash {
 }
 
 func getBVMETHTotalSupplyKey() common.Hash {
-	position := common.Big2
-	hasher := sha3.NewLegacyKeccak256()
-	hasher.Write(common.LeftPadBytes(position.Bytes(), 32))
-	digest := hasher.Sum(nil)
-	return common.BytesToHash(digest)
+	return common.BytesToHash(common.Big2.Bytes())
 }
 
-func (st *StateTransition) generateMintEvent(mintAddress common.Address, mintValue *big.Int) {
+func (st *StateTransition) generateBVMETHMintEvent(mintAddress common.Address, mintValue *big.Int) {
 	// keccak("Mint(address,uint256)") = "0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885"
 	methodHash := common.HexToHash("0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885")
 	topics := make([]common.Hash, 2)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"math/big"
 
@@ -154,7 +153,6 @@ type Message struct {
 
 // TransactionToMessage converts a transaction into a Message.
 func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.Int) (*Message, error) {
-	log.Printf("!!!!!!!!!!!!!!  tx2msg : ethvalue = %v", tx.ETHValue())
 	msg := &Message{
 		Nonce:             tx.Nonce(),
 		GasLimit:          tx.Gas(),
@@ -354,26 +352,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.state.AddBalance(st.msg.From, mint)
 	}
 	//add eth value
-	if st.msg.ETHValue != nil && st.msg.ETHValue.Uint64() != 0 {
-		log.Printf("debug----- ethvalue = %v", st.msg.ETHValue.Uint64())
-	} else {
-		log.Printf("debug----- ethvalue is nil ")
-
-	}
-
 	if ethValue := st.msg.ETHValue; ethValue != nil && ethValue.Cmp(big.NewInt(0)) != 0 {
 		BVM_ETH := common.HexToAddress(BVM_ETH_ADDR)
-
 		key := getBVMETHBalanceKey(*st.msg.To)
 		value := st.state.GetState(BVM_ETH, key)
-		log.Printf("debug----- to address= %v", st.msg.To.Hex())
-		log.Printf("debug----- to address value = %v", value.Big().Uint64())
-		log.Printf("debug----- bvm address value = %v", BVM_ETH.Hex())
-
 		bal := value.Big()
 		bal = bal.Add(bal, ethValue)
 		st.state.SetState(BVM_ETH, key, common.BigToHash(bal))
-		log.Printf("kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk")
 		//st.state.AddLog()
 		//types.Log{}
 	}
@@ -556,6 +541,7 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 func (st *StateTransition) gasUsed() uint64 {
 	return st.initialGas - st.gasRemaining
 }
+
 func getBVMETHBalanceKey(addr common.Address) common.Hash {
 	position := common.Big0
 	hasher := sha3.NewLegacyKeccak256()

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -33,6 +33,8 @@ type DepositTx struct {
 	To *common.Address `rlp:"nil"`
 	// Mint is minted on L2, locked on L1, nil if no minting.
 	Mint *big.Int `rlp:"nil"`
+	// EthValue means L2 BVM_ETH mint tag, nil means that there is no need to mint BVM_ETH.
+	EthValue *big.Int `rlp:"nil"`
 	// Value is transferred from L2 balance, executed after Mint (if any)
 	Value *big.Int
 	// gas limit
@@ -54,12 +56,16 @@ func (tx *DepositTx) copy() TxData {
 		Gas:                 tx.Gas,
 		IsSystemTransaction: tx.IsSystemTransaction,
 		Data:                common.CopyBytes(tx.Data),
+		EthValue:            new(big.Int),
 	}
 	if tx.Mint != nil {
 		cpy.Mint = new(big.Int).Set(tx.Mint)
 	}
 	if tx.Value != nil {
 		cpy.Value.Set(tx.Value)
+	}
+	if tx.EthValue != nil {
+		cpy.EthValue.Set(tx.Value)
 	}
 	return cpy
 }

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -65,7 +65,7 @@ func (tx *DepositTx) copy() TxData {
 		cpy.Value.Set(tx.Value)
 	}
 	if tx.EthValue != nil {
-		cpy.EthValue.Set(tx.Value)
+		cpy.EthValue.Set(tx.EthValue)
 	}
 	return cpy
 }

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -33,14 +33,14 @@ type DepositTx struct {
 	To *common.Address `rlp:"nil"`
 	// Mint is minted on L2, locked on L1, nil if no minting.
 	Mint *big.Int `rlp:"nil"`
-	// EthValue means L2 BVM_ETH mint tag, nil means that there is no need to mint BVM_ETH.
-	EthValue *big.Int `rlp:"nil"`
 	// Value is transferred from L2 balance, executed after Mint (if any)
 	Value *big.Int
 	// gas limit
 	Gas uint64
 	// Field indicating if this transaction is exempt from the L2 gas limit.
 	IsSystemTransaction bool
+	// EthValue means L2 BVM_ETH mint tag, nil means that there is no need to mint BVM_ETH.
+	EthValue *big.Int `rlp:"nil"`
 	// Normal Tx data
 	Data []byte
 }
@@ -56,7 +56,7 @@ func (tx *DepositTx) copy() TxData {
 		Gas:                 tx.Gas,
 		IsSystemTransaction: tx.IsSystemTransaction,
 		Data:                common.CopyBytes(tx.Data),
-		EthValue:            new(big.Int),
+		EthValue:            nil,
 	}
 	if tx.Mint != nil {
 		cpy.Mint = new(big.Int).Set(tx.Mint)
@@ -65,7 +65,7 @@ func (tx *DepositTx) copy() TxData {
 		cpy.Value.Set(tx.Value)
 	}
 	if tx.EthValue != nil {
-		cpy.EthValue.Set(tx.EthValue)
+		cpy.EthValue = new(big.Int).Set(tx.EthValue)
 	}
 	return cpy
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -326,7 +326,7 @@ func (tx *Transaction) SourceHash() common.Hash {
 	return common.Hash{}
 }
 
-// Mint returns the ETH to mint in the deposit tx.
+// Mint returns the MNT to mint in the deposit tx.
 // This returns nil if there is nothing to mint, or if this is not a deposit tx.
 func (tx *Transaction) Mint() *big.Int {
 	if dep, ok := tx.inner.(*DepositTx); ok {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -335,6 +335,15 @@ func (tx *Transaction) Mint() *big.Int {
 	return nil
 }
 
+// ETHValue returns the BVM_ETH to mint in the deposit tx.
+// This returns nil if there is nothing to mint, or if this is not a deposit tx.
+func (tx *Transaction) ETHValue() *big.Int {
+	if dep, ok := tx.inner.(*DepositTx); ok {
+		return dep.EthValue
+	}
+	return nil
+}
+
 // IsDepositTx returns true if the transaction is a deposit tx type.
 func (tx *Transaction) IsDepositTx() bool {
 	return tx.Type() == DepositTxType

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -48,6 +48,7 @@ type txJSON struct {
 	SourceHash *common.Hash    `json:"sourceHash,omitempty"`
 	From       *common.Address `json:"from,omitempty"`
 	Mint       *hexutil.Big    `json:"mint,omitempty"`
+	EthValue   *hexutil.Big    `json:"ethValue,omitempty"`
 	IsSystemTx *bool           `json:"isSystemTx,omitempty"`
 
 	// Access list transaction fields:
@@ -111,6 +112,9 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.From = &itx.From
 		if itx.Mint != nil {
 			enc.Mint = (*hexutil.Big)(itx.Mint)
+		}
+		if itx.EthValue != nil {
+			enc.EthValue = (*hexutil.Big)(itx.EthValue)
 		}
 		enc.IsSystemTx = &itx.IsSystemTransaction
 		// other fields will show up as null.
@@ -310,6 +314,8 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		itx.Value = (*big.Int)(dec.Value)
 		// mint may be omitted or nil if there is nothing to mint.
 		itx.Mint = (*big.Int)(dec.Mint)
+		// ethValue may be omitted or nil if there is nothing to mint.
+		itx.EthValue = (*big.Int)(dec.EthValue)
 		if dec.Data == nil {
 			return errors.New("missing required field 'input' in transaction")
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1430,6 +1430,7 @@ type RPCTransaction struct {
 	// deposit-tx only
 	SourceHash *common.Hash `json:"sourceHash,omitempty"`
 	Mint       *hexutil.Big `json:"mint,omitempty"`
+	EthValue   *hexutil.Big `json:"ethValue,omitempty"`
 	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
 }
 
@@ -1469,6 +1470,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			result.IsSystemTx = &isSystemTx
 		}
 		result.Mint = (*hexutil.Big)(tx.Mint())
+		result.EthValue = (*hexutil.Big)(tx.ETHValue())
 		if receipt != nil && receipt.DepositNonce != nil {
 			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)
 		}


### PR DESCRIPTION
Core change:
1. add `ethValue` in depositTx  and update the derive function for DepositTx
2. add `BVM_ETH` mint action on  `state_transition.go`