### PR TITLE
[R4R]-[fee]feat: fix estimateGas to avoid maxPriorityFeePerGas > maxFeePerGas

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -260,6 +260,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 	if runMode == core.GasEstimationMode || runMode == core.GasEstimationWithSkipCheckBalanceMode {
 		gasPrice = gasPriceForEstimate.ToInt()
 		gasFeeCap = gasPriceForEstimate.ToInt()
+		gasTipCap = gasPriceForEstimate.ToInt()
 	}
 
 	value := new(big.Int)


### PR DESCRIPTION
Core change:
- use default gasPrice to set `gasPrice`, `gasFeeCap` and `gasTipCap` to avoid `maxPriorityFeePerGas` > `maxFeePerGas` when `estimateGas`