### PR TITLE
[R4R]-[transactionReceipt]feat: fix query legacy txs through transactionReceipt

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -147,6 +147,12 @@ type LegacyOptimismStoredReceiptRLP struct {
 	L1GasPrice        *big.Int
 	L1Fee             *big.Int
 	FeeScalar         string
+
+	// DAGasUsed,DAGasPrice,DAFee These values are not used to collect fee,
+	// so decode from ledger, but not exposed outside.
+	DAGasUsed  *big.Int
+	DAGasPrice *big.Int
+	DAFee      *big.Int
 }
 
 // LogForStorage is a wrapper around a Log that handles

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1933,7 +1933,9 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
 		fields["l1FeeScalar"] = receipt.FeeScalar.String()
-		fields["tokenRatio"] = (*hexutil.Big)(receipt.TokenRatio)
+		if receipt.TokenRatio != nil {
+			fields["tokenRatio"] = (*hexutil.Big)(receipt.TokenRatio)
+		}
 	}
 	if s.b.ChainConfig().Optimism != nil && tx.IsDepositTx() && receipt.DepositNonce != nil {
 		fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)


### PR DESCRIPTION
Core change:
- There are `DA*` values stored in legacy version ledger, and those transactions should be compatible for querying by `eth_getTransactionReceipt`