### PR TITLE
[R4R]-feat: mantle v1 -> v2

### DIFF
--- a/.github/workflows/check-docker-build.yml
+++ b/.github/workflows/check-docker-build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - develop
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '**'
 jobs:

--- a/.github/workflows/check-docker-build.yml
+++ b/.github/workflows/check-docker-build.yml
@@ -1,0 +1,29 @@
+name: Check Docker Build
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
+    paths:
+      - '**'
+jobs:
+  CheckDockerBuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+          token: ${{ secrets.PAT }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Checking Docker Build
+        run: |
+          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+          response=$(curl -H 'authorization: Bearer ${{ secrets.PAT }}' -H "Accept: application/vnd.github.v3+json" -s -X GET -G $URL)
+          UPDATEFILE_DIR=$(echo "${response}" | jq -r '.[] | .filename')
+          echo $UPDATEFILE_DIR
+          cmd="docker build -f Dockerfile -t test:v1 ."
+          echo -e "\e[32m$cmd\e[0m"
+          $cmd

--- a/.github/workflows/check-make-build.yml
+++ b/.github/workflows/check-make-build.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - develop
-      - 'releases/**'
+      - 'release/**'
     paths:
       - '**'
 jobs:

--- a/.github/workflows/check-make-build.yml
+++ b/.github/workflows/check-make-build.yml
@@ -1,0 +1,29 @@
+name: Check Make Build
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - 'releases/**'
+    paths:
+      - '**'
+jobs:
+  CheckMakeBuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+          token: ${{ secrets.PAT }}
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          golang-version: 1.19
+      - name: Checking Make Build
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential  coreutils libuv1 libudev-dev libusb-1.0-0-dev
+          make geth
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ build/_vendor/pkg
 /build/bin/
 /geth*.zip
 
+vendor
+
 # travis
 profile.tmp
 profile.cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,15 @@ RUN cd /go-ethereum && go run build/ci.go install -static ./cmd/geth
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:latest
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates jq
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/
+COPY entrypoint.sh /app/entrypoint.sh
 
 EXPOSE 8545 8546 30303 30303/udp
-ENTRYPOINT ["geth"]
+
+WORKDIR /app
+
+ENTRYPOINT ["/bin/sh", "/app/entrypoint.sh"]
 
 # Add some metadata labels to help programatic image consumption
 ARG COMMIT=""

--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -710,7 +710,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	}
 	// Ensure message is initialized properly.
 	if call.Gas == 0 {
-		call.Gas = 50000000
+		call.Gas = core.DefaultMantleBlockGasLimit
 	}
 	if call.Value == nil {
 		call.Value = new(big.Int)

--- a/beacon/engine/gen_blockparams.go
+++ b/beacon/engine/gen_blockparams.go
@@ -5,6 +5,7 @@ package engine
 import (
 	"encoding/json"
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -23,6 +24,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              bool                `json:"noTxPool,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
+		BaseFee               *big.Int            `json:"baseFee,omitempty" gencodec:"optional"`
 	}
 	var enc PayloadAttributes
 	enc.Timestamp = hexutil.Uint64(p.Timestamp)
@@ -37,6 +39,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 	}
 	enc.NoTxPool = p.NoTxPool
 	enc.GasLimit = (*hexutil.Uint64)(p.GasLimit)
+	enc.BaseFee = p.BaseFee
 	return json.Marshal(&enc)
 }
 
@@ -50,6 +53,7 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              *bool               `json:"noTxPool,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
+		BaseFee               *big.Int            `json:"baseFee,omitempty" gencodec:"optional"`
 	}
 	var dec PayloadAttributes
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -81,6 +85,9 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 	}
 	if dec.GasLimit != nil {
 		p.GasLimit = (*uint64)(dec.GasLimit)
+	}
+	if dec.BaseFee != nil {
+		p.BaseFee = dec.BaseFee
 	}
 	return nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -43,6 +43,8 @@ type PayloadAttributes struct {
 	NoTxPool bool `json:"noTxPool,omitempty" gencodec:"optional"`
 	// GasLimit is a field for rollups: if set, this sets the exact gas limit the block produced with.
 	GasLimit *uint64 `json:"gasLimit,omitempty" gencodec:"optional"`
+	// BaseFee is a field for rollups: if set, this sets the exact base fee the block produced with.
+	BaseFee *big.Int `json:"baseFee,omitempty" gencodec:"optional"`
 }
 
 // JSON type overrides for PayloadAttributes.

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -946,6 +946,11 @@ var (
 		Usage:    "Disable transaction pool gossip.",
 		Category: flags.RollupCategory,
 	}
+	RollupEnableTxPoolAdmissionFlag = &cli.BoolFlag{
+		Name:     "rollup.enabletxpooladmission",
+		Usage:    "Add RPC-submitted transactions to the txpool (on by default if --rollup.sequencerhttp is not set).",
+		Category: flags.RollupCategory,
+	}
 	RollupComputePendingBlock = &cli.BoolFlag{
 		Name:     "rollup.computependingblock",
 		Usage:    "By default the pending block equals the latest block to save resources and not leak txs from the tx-pool, this flag enables computing of the pending block from the tx-pool instead.",
@@ -1926,6 +1931,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.RollupHistoricalRPCTimeout = ctx.Duration(RollupHistoricalRPCTimeoutFlag.Name)
 	}
 	cfg.RollupDisableTxPoolGossip = ctx.Bool(RollupDisableTxPoolGossipFlag.Name)
+	cfg.RollupDisableTxPoolAdmission = cfg.RollupSequencerHTTP != "" && !ctx.Bool(RollupEnableTxPoolAdmissionFlag.Name)
 	// Override any default configs for hard coded networks.
 	switch {
 	case ctx.Bool(MainnetFlag.Name):

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -54,7 +54,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		return new(big.Int).SetUint64(params.InitialBaseFee)
 	}
 
-	if config.IsMantleBaseFee(parent.Number) {
+	if config.IsMantleBaseFee(parent.Time) {
 		return new(big.Int).Set(parent.BaseFee)
 	}
 

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -44,12 +44,6 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	if header.BaseFee == nil {
 		return fmt.Errorf("header is missing baseFee")
 	}
-	// Verify the baseFee is correct based on the parent header.
-	expectedBaseFee := CalcBaseFee(config, parent)
-	if header.BaseFee.Cmp(expectedBaseFee) != 0 {
-		return fmt.Errorf("invalid baseFee: have %s, want %s, parentBaseFee %s, parentGasUsed %d",
-			header.BaseFee, expectedBaseFee, parent.BaseFee, parent.GasUsed)
-	}
 	return nil
 }
 

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -54,6 +54,10 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		return new(big.Int).SetUint64(params.InitialBaseFee)
 	}
 
+	if config.IsMantleBaseFee(parent.Number) {
+		return new(big.Int).Set(parent.BaseFee)
+	}
+
 	parentGasTarget := parent.GasLimit / config.ElasticityMultiplier()
 	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
 	if parent.GasUsed == parentGasTarget {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -151,6 +151,10 @@ var defaultCacheConfig = &CacheConfig{
 	SnapshotWait:   true,
 }
 
+const (
+	DefaultMantleBlockGasLimit = 0x4000000000000
+)
+
 // BlockChain represents the canonical chain given a database with a genesis
 // block. The Blockchain manages chain imports, reverts, chain reorganisations.
 //

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -307,9 +307,9 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				config.RegolithTime = &params.BaseGoerliRegolithTime
 			}
 
-			mantleUpgradeChainConfig := getUpgradeConfigForMantle(params.MantleSepoliaChainId)
+			mantleUpgradeChainConfig := GetUpgradeConfigForMantle(config.ChainID)
 			if mantleUpgradeChainConfig != nil {
-				config.MantleBaseFeeBlock = mantleUpgradeChainConfig.MantleBaseFeeForSepolia
+				config.BaseFeeTime = mantleUpgradeChainConfig.BaseFeeTime
 			}
 
 			if overrides != nil && overrides.OverrideShanghai != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -267,7 +267,8 @@ func (e *GenesisMismatchError) Error() string {
 
 // ChainOverrides contains the changes to chain config.
 type ChainOverrides struct {
-	OverrideShanghai *uint64
+	OverrideMantleBaseFee *big.Int
+	OverrideShanghai      *uint64
 	// optimism
 	OverrideOptimismBedrock  *big.Int
 	OverrideOptimismRegolith *uint64
@@ -305,6 +306,12 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				// Apply Base Goerli regolith time
 				config.RegolithTime = &params.BaseGoerliRegolithTime
 			}
+
+			mantleUpgradeChainConfig := getUpgradeConfigForMantle(params.MantleSepoliaChainId)
+			if mantleUpgradeChainConfig != nil {
+				config.MantleBaseFeeBlock = mantleUpgradeChainConfig.MantleBaseFeeForSepolia
+			}
+
 			if overrides != nil && overrides.OverrideShanghai != nil {
 				config.ShanghaiTime = overrides.OverrideShanghai
 			}

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -14,7 +14,7 @@ var (
 
 	MantleSepoliaUpgradeConfig = MantleUpgradeChainConfig{
 		ChainID:     params.MantleSepoliaChainId,
-		BaseFeeTime: u64Ptr(1_704_877_200),
+		BaseFeeTime: u64Ptr(1_704_891_600),
 	}
 	MantleLocalUpgradeConfig = MantleUpgradeChainConfig{
 		ChainID:     params.MantleLocalChainId,

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -20,6 +20,9 @@ var (
 		ChainID:     params.MantleLocalChainId,
 		BaseFeeTime: u64Ptr(0),
 	}
+	MantleDefaultUpgradeConfig = MantleUpgradeChainConfig{
+		BaseFeeTime: u64Ptr(0),
+	}
 )
 
 type MantleUpgradeChainConfig struct {
@@ -39,7 +42,7 @@ func GetUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
 	case params.MantleLocalChainId.Int64():
 		return &MantleLocalUpgradeConfig
 	default:
-		return nil
+		return &MantleDefaultUpgradeConfig
 	}
 }
 

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -1,0 +1,28 @@
+package core
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	MantleSepoliaUpgradeConfig = MantleUpgradeChainConfig{
+		ChainID:                 params.MantleSepoliaChainId,
+		MantleBaseFeeForSepolia: big.NewInt(473_611),
+	}
+)
+
+type MantleUpgradeChainConfig struct {
+	ChainID                 *big.Int `json:"chainId"`                 // chainId identifies the current chain and is used for replay protection
+	MantleBaseFeeForSepolia *big.Int `json:"MantleBaseFeeForSepolia"` // Mantle BaseFee switch block (nil = no fork, 0 = already on mantle baseFee)
+}
+
+func getUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
+	switch chainID {
+	case params.MantleSepoliaChainId:
+		return &MantleSepoliaUpgradeConfig
+	default:
+		return nil
+	}
+}

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -14,7 +14,7 @@ var (
 
 	MantleSepoliaUpgradeConfig = MantleUpgradeChainConfig{
 		ChainID:     params.MantleSepoliaChainId,
-		BaseFeeTime: u64Ptr(1_703_759_533),
+		BaseFeeTime: u64Ptr(1_704_877_200),
 	}
 	MantleLocalUpgradeConfig = MantleUpgradeChainConfig{
 		ChainID:     params.MantleLocalChainId,

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -7,22 +7,42 @@ import (
 )
 
 var (
+	MantleMainnetUpgradeConfig = MantleUpgradeChainConfig{
+		ChainID:     params.MantleMainnetChainId,
+		BaseFeeTime: u64Ptr(0),
+	}
+
 	MantleSepoliaUpgradeConfig = MantleUpgradeChainConfig{
-		ChainID:                 params.MantleSepoliaChainId,
-		MantleBaseFeeForSepolia: big.NewInt(473_611),
+		ChainID:     params.MantleSepoliaChainId,
+		BaseFeeTime: u64Ptr(1_703_759_533),
+	}
+	MantleLocalUpgradeConfig = MantleUpgradeChainConfig{
+		ChainID:     params.MantleLocalChainId,
+		BaseFeeTime: u64Ptr(0),
 	}
 )
 
 type MantleUpgradeChainConfig struct {
-	ChainID                 *big.Int `json:"chainId"`                 // chainId identifies the current chain and is used for replay protection
-	MantleBaseFeeForSepolia *big.Int `json:"MantleBaseFeeForSepolia"` // Mantle BaseFee switch block (nil = no fork, 0 = already on mantle baseFee)
+	ChainID     *big.Int `json:"chainId"`     // chainId identifies the current chain and is used for replay protection
+	BaseFeeTime *uint64  `json:"BaseFeeTime"` // Mantle BaseFee switch time (nil = no fork, 0 = already on mantle baseFee)
 }
 
-func getUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
-	switch chainID {
-	case params.MantleSepoliaChainId:
+func GetUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
+	if chainID == nil {
+		return nil
+	}
+	switch chainID.Int64() {
+	case params.MantleMainnetChainId.Int64():
+		return &MantleMainnetUpgradeConfig
+	case params.MantleSepoliaChainId.Int64():
 		return &MantleSepoliaUpgradeConfig
+	case params.MantleLocalChainId.Int64():
+		return &MantleLocalUpgradeConfig
 	default:
 		return nil
 	}
+}
+
+func u64Ptr(v uint64) *uint64 {
+	return &v
 }

--- a/core/mantle_upgrade_test.go
+++ b/core/mantle_upgrade_test.go
@@ -8,7 +8,7 @@ import (
 var (
 	MantleMainnetChainId = big.NewInt(5000)
 	MantleSepoliaChainId = big.NewInt(5003)
-	NonExistChainID      = big.NewInt(-1)
+	OtherChainID         = big.NewInt(1_000_000)
 )
 
 func TestGetUpgradeConfigForMantle(t *testing.T) {
@@ -22,8 +22,13 @@ func TestGetUpgradeConfigForMantle(t *testing.T) {
 		t.Errorf("wrong baseFeeTime: got %v, want %v", *sepoliaUpgradeConfig.BaseFeeTime, *MantleSepoliaUpgradeConfig.BaseFeeTime)
 	}
 
-	upgradeConfig := GetUpgradeConfigForMantle(NonExistChainID)
+	upgradeConfig := GetUpgradeConfigForMantle(nil)
 	if upgradeConfig != nil {
 		t.Errorf("upgradeConfig should be nil, upgradeConfig: got %v, want %v", upgradeConfig, nil)
+	}
+
+	defaultUpgradeConfig := GetUpgradeConfigForMantle(OtherChainID)
+	if *defaultUpgradeConfig.BaseFeeTime != *MantleDefaultUpgradeConfig.BaseFeeTime {
+		t.Errorf("wrong baseFeeTime: got %v, want %v", *defaultUpgradeConfig.BaseFeeTime, *MantleDefaultUpgradeConfig.BaseFeeTime)
 	}
 }

--- a/core/mantle_upgrade_test.go
+++ b/core/mantle_upgrade_test.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+)
+
+var (
+	MantleMainnetChainId = big.NewInt(5000)
+	MantleSepoliaChainId = big.NewInt(5003)
+	NonExistChainID      = big.NewInt(-1)
+)
+
+func TestGetUpgradeConfigForMantle(t *testing.T) {
+	mainnetUpgradeConfig := GetUpgradeConfigForMantle(MantleMainnetChainId)
+	if *mainnetUpgradeConfig.BaseFeeTime != *MantleMainnetUpgradeConfig.BaseFeeTime {
+		t.Errorf("wrong baseFeeTime: got %v, want %v", *mainnetUpgradeConfig.BaseFeeTime, *MantleMainnetUpgradeConfig.BaseFeeTime)
+	}
+
+	sepoliaUpgradeConfig := GetUpgradeConfigForMantle(MantleSepoliaChainId)
+	if *sepoliaUpgradeConfig.BaseFeeTime != *MantleSepoliaUpgradeConfig.BaseFeeTime {
+		t.Errorf("wrong baseFeeTime: got %v, want %v", *sepoliaUpgradeConfig.BaseFeeTime, *MantleSepoliaUpgradeConfig.BaseFeeTime)
+	}
+
+	upgradeConfig := GetUpgradeConfigForMantle(NonExistChainID)
+	if upgradeConfig != nil {
+		t.Errorf("upgradeConfig should be nil, upgradeConfig: got %v, want %v", upgradeConfig, nil)
+	}
+}

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -679,15 +679,34 @@ type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
 	Logs              []*types.Log
+	// DepositNonce was introduced in Regolith to store the actual nonce used by deposit transactions.
+	// Must be nil for any transactions prior to Regolith or that aren't deposit transactions.
+	DepositNonce *uint64 `rlp:"optional"`
 
 	// Remaining fields are declared to allow the receipt RLP to be parsed without errors.
 	// However, they must not be used as they may not be populated correctly due to multiple receipt formats
 	// being combined into a single list of optional fields which can be mistaken for each other.
-	// DepositNonce (*uint64) from Regolith deposit tx receipts will be parsed into L1GasUsed
-	L1GasUsed  *big.Int `rlp:"optional"` // OVM legacy
-	L1GasPrice *big.Int `rlp:"optional"` // OVM legacy
-	L1Fee      *big.Int `rlp:"optional"` // OVM legacy
-	FeeScalar  string   `rlp:"optional"` // OVM legacy
+	L1GasUsed  *big.Int `rlp:"optional"`
+	L1GasPrice *big.Int `rlp:"optional"`
+	L1Fee      *big.Int `rlp:"optional"`
+	FeeScalar  string   `rlp:"optional"`
+	TokenRatio *big.Int `rlp:"optional"`
+}
+
+type legacyOptimismStoredReceiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Logs              []*types.Log
+	L1GasUsed         *big.Int `rlp:"optional"`
+	L1GasPrice        *big.Int `rlp:"optional"`
+	L1Fee             *big.Int `rlp:"optional"`
+	FeeScalar         string   `rlp:"optional"`
+
+	// DAGasUsed,DAGasPrice,DAFee These values are not used to collect fee,
+	// so decode from ledger, but not exposed outside.
+	DAGasUsed  *big.Int `rlp:"optional"`
+	DAGasPrice *big.Int `rlp:"optional"`
+	DAFee      *big.Int `rlp:"optional"`
 }
 
 // ReceiptLogs is a barebone version of ReceiptForStorage which only keeps
@@ -700,7 +719,12 @@ type receiptLogs struct {
 // DecodeRLP implements rlp.Decoder.
 func (r *receiptLogs) DecodeRLP(s *rlp.Stream) error {
 	var stored storedReceiptRLP
-	if err := s.Decode(&stored); err != nil {
+	if err := s.Decode(&stored); err == nil {
+		r.Logs = stored.Logs
+		return nil
+	}
+	var storedLegacy legacyOptimismStoredReceiptRLP
+	if err := s.Decode(&storedLegacy); err != nil {
 		return err
 	}
 	r.Logs = stored.Logs

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -718,16 +718,26 @@ type receiptLogs struct {
 
 // DecodeRLP implements rlp.Decoder.
 func (r *receiptLogs) DecodeRLP(s *rlp.Stream) error {
+	blob, err := s.Raw()
+	if err != nil {
+		return err
+	}
+
+	// First try to decode the latest receipt database format, try the pre-bedrock Optimism legacy format otherwise.
 	var stored storedReceiptRLP
-	if err := s.Decode(&stored); err == nil {
+	err = rlp.DecodeBytes(blob, &stored)
+	if err == nil {
 		r.Logs = stored.Logs
 		return nil
 	}
+
 	var storedLegacy legacyOptimismStoredReceiptRLP
-	if err := s.Decode(&storedLegacy); err != nil {
+	err = rlp.DecodeBytes(blob, &storedLegacy)
+	if err != nil {
 		return err
 	}
-	r.Logs = stored.Logs
+
+	r.Logs = storedLegacy.Logs
 	return nil
 }
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -25,6 +25,7 @@ import (
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"golang.org/x/crypto/sha3"
@@ -439,9 +440,15 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 	//add eth value
 	if ethValue := st.msg.ETHValue; ethValue != nil && ethValue.Cmp(big.NewInt(0)) != 0 {
-		st.addBVMETHBalance(ethValue)
+		var ethRecipient common.Address
+		if st.msg.To != nil {
+			ethRecipient = *st.msg.To
+		} else {
+			ethRecipient = crypto.CreateAddress(st.msg.From, st.evm.StateDB.GetNonce(st.msg.From))
+		}
+		st.addBVMETHBalance(ethRecipient, ethValue)
 		st.addBVMETHTotalSupply(ethValue)
-		st.generateBVMETHMintEvent(*st.msg.To, ethValue)
+		st.generateBVMETHMintEvent(ethRecipient, ethValue)
 	}
 	snap := st.state.Snapshot()
 
@@ -664,8 +671,8 @@ func (st *StateTransition) gasUsed() uint64 {
 	return st.initialGas - st.gasRemaining
 }
 
-func (st *StateTransition) addBVMETHBalance(ethValue *big.Int) {
-	key := getBVMETHBalanceKey(*st.msg.To)
+func (st *StateTransition) addBVMETHBalance(ethRecipient common.Address, ethValue *big.Int) {
+	key := getBVMETHBalanceKey(ethRecipient)
 	value := st.state.GetState(BVM_ETH_ADDR, key)
 	bal := value.Big()
 	bal = bal.Add(bal, ethValue)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -516,7 +516,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	st.gasRemaining -= gas
 
 	var l1Gas uint64
-	if !st.msg.IsDepositTx && !st.msg.IsSystemTx && st.msg.RunMode != GasEstimationWithSkipCheckBalanceMode {
+	if !st.msg.IsDepositTx && !st.msg.IsSystemTx {
 		if st.msg.GasPrice.Cmp(common.Big0) > 0 && l1Cost != nil {
 			l1Gas = new(big.Int).Div(l1Cost, st.msg.GasPrice).Uint64()
 			if st.msg.GasLimit < l1Gas {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -289,7 +289,7 @@ func (st *StateTransition) buyGas() (*big.Int, error) {
 		st.CalculateRollupGasDataFromMessage()
 	}
 	if st.evm.Context.L1CostFunc != nil && st.msg.RunMode != EthcallMode {
-		l1Cost = st.evm.Context.L1CostFunc(st.evm.Context.BlockNumber.Uint64(), st.evm.Context.Time, st.msg.RollupDataGas, st.msg.IsDepositTx)
+		l1Cost = st.evm.Context.L1CostFunc(st.evm.Context.BlockNumber.Uint64(), st.evm.Context.Time, st.msg.RollupDataGas, st.msg.IsDepositTx, st.msg.To)
 	}
 	if l1Cost != nil && (st.msg.RunMode == GasEstimationMode || st.msg.RunMode == GasEstimationWithSkipCheckBalanceMode) {
 		mgval = mgval.Add(mgval, l1Cost)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -25,12 +25,14 @@ import (
 	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
-
 	"golang.org/x/crypto/sha3"
 )
 
-const BVM_ETH_ADDR = "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111"
+var (
+	BVM_ETH_ADDR = common.HexToAddress("0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111")
+)
 
 // ExecutionResult includes all output after executing given evm
 // message no matter the execution itself is successful or not.
@@ -149,11 +151,16 @@ type Message struct {
 	IsDepositTx   bool                // IsDepositTx indicates the message is force-included and can persist a mint.
 	Mint          *big.Int            // Mint is the amount to mint before EVM processing, or nil if there is no minting.
 	ETHValue      *big.Int            // ETHValue is the amount to mint BVM_ETH before EVM processing, or nil if there is no minting.
+	MetaTxParams  *types.MetaTxParams // MetaTxParams contains necessary parameter to sponsor gas fee for msg.From.
 	RollupDataGas types.RollupGasData // RollupDataGas indicates the rollup cost of the message, 0 if not a rollup or no cost.
 }
 
 // TransactionToMessage converts a transaction into a Message.
 func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.Int) (*Message, error) {
+	metaTxParams, err := types.DecodeAndVerifyMetaTxParams(tx)
+	if err != nil {
+		return nil, err
+	}
 	msg := &Message{
 		Nonce:             tx.Nonce(),
 		GasLimit:          tx.Gas(),
@@ -169,13 +176,13 @@ func TransactionToMessage(tx *types.Transaction, s types.Signer, baseFee *big.In
 		Mint:              tx.Mint(),
 		RollupDataGas:     tx.RollupDataGas(),
 		ETHValue:          tx.ETHValue(),
+		MetaTxParams:      metaTxParams,
 		SkipAccountChecks: false,
 	}
 	// If baseFee provided, set gasPrice to effectiveGasPrice.
 	if baseFee != nil {
 		msg.GasPrice = cmath.BigMin(msg.GasPrice.Add(msg.GasTipCap, baseFee), msg.GasFeeCap)
 	}
-	var err error
 	msg.From, err = types.Sender(s, tx)
 	return msg, err
 }
@@ -241,6 +248,9 @@ func (st *StateTransition) to() common.Address {
 }
 
 func (st *StateTransition) buyGas() error {
+	if err := st.applyMetaTransaction(); err != nil {
+		return err
+	}
 	mgval := new(big.Int).SetUint64(st.msg.GasLimit)
 	mgval = mgval.Mul(mgval, st.msg.GasPrice)
 	var l1Cost *big.Int
@@ -259,16 +269,51 @@ func (st *StateTransition) buyGas() error {
 			balanceCheck.Add(balanceCheck, l1Cost)
 		}
 	}
-	if have, want := st.state.GetBalance(st.msg.From), balanceCheck; have.Cmp(want) < 0 {
-		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
+
+	if st.msg.MetaTxParams != nil {
+		pureGasFeeValue := new(big.Int).Sub(balanceCheck, st.msg.Value)
+		sponsorAmount, selfPayAmount := types.CalculateSponsorPercentAmount(st.msg.MetaTxParams, pureGasFeeValue)
+		if have, want := st.state.GetBalance(st.msg.MetaTxParams.GasFeeSponsor), sponsorAmount; have.Cmp(want) < 0 {
+			return fmt.Errorf("%w: gas fee sponsor %v have %v want %v", ErrInsufficientFunds, st.msg.MetaTxParams.GasFeeSponsor.Hex(), have, want)
+		}
+		selfPayAmount = new(big.Int).Add(selfPayAmount, st.msg.Value)
+		if have, want := st.state.GetBalance(st.msg.From), selfPayAmount; have.Cmp(want) < 0 {
+			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
+		}
+	} else {
+		if have, want := st.state.GetBalance(st.msg.From), balanceCheck; have.Cmp(want) < 0 {
+			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
+		}
 	}
+
 	if err := st.gp.SubGas(st.msg.GasLimit); err != nil {
 		return err
 	}
 	st.gasRemaining += st.msg.GasLimit
 
 	st.initialGas = st.msg.GasLimit
-	st.state.SubBalance(st.msg.From, mgval)
+	if st.msg.MetaTxParams != nil {
+		sponsorAmount, selfPayAmount := types.CalculateSponsorPercentAmount(st.msg.MetaTxParams, mgval)
+		st.state.SubBalance(st.msg.MetaTxParams.GasFeeSponsor, sponsorAmount)
+		st.state.SubBalance(st.msg.From, selfPayAmount)
+		log.Debug("BuyGas for metaTx",
+			"sponsor", st.msg.MetaTxParams.GasFeeSponsor.String(), "amount", sponsorAmount.String(),
+			"user", st.msg.From.String(), "amount", selfPayAmount.String())
+	} else {
+		st.state.SubBalance(st.msg.From, mgval)
+	}
+	return nil
+}
+
+func (st *StateTransition) applyMetaTransaction() error {
+	if st.msg.MetaTxParams == nil {
+		return nil
+	}
+	if st.msg.MetaTxParams.ExpireHeight < st.evm.Context.BlockNumber.Uint64() {
+		return types.ErrExpiredMetaTx
+	}
+
+	st.msg.Data = st.msg.MetaTxParams.Payload
 	return nil
 }
 
@@ -526,7 +571,16 @@ func (st *StateTransition) refundGas(refundQuotient uint64) {
 
 	// Return ETH for remaining gas, exchanged at the original rate.
 	remaining := new(big.Int).Mul(new(big.Int).SetUint64(st.gasRemaining), st.msg.GasPrice)
-	st.state.AddBalance(st.msg.From, remaining)
+	if st.msg.MetaTxParams != nil {
+		sponsorRefundAmount, selfRefundAmount := types.CalculateSponsorPercentAmount(st.msg.MetaTxParams, remaining)
+		st.state.AddBalance(st.msg.MetaTxParams.GasFeeSponsor, sponsorRefundAmount)
+		st.state.AddBalance(st.msg.From, selfRefundAmount)
+		log.Debug("RefundGas for metaTx",
+			"sponsor", st.msg.MetaTxParams.GasFeeSponsor.String(), "refundAmount", sponsorRefundAmount.String(),
+			"user", st.msg.From.String(), "refundAmount", selfRefundAmount.String())
+	} else {
+		st.state.AddBalance(st.msg.From, remaining)
+	}
 
 	// Also return remaining gas to the block gas counter so it is
 	// available for the next transaction.
@@ -539,21 +593,19 @@ func (st *StateTransition) gasUsed() uint64 {
 }
 
 func (st *StateTransition) addBVMETHBalance(ethValue *big.Int) {
-	bvmEth := common.HexToAddress(BVM_ETH_ADDR)
 	key := getBVMETHBalanceKey(*st.msg.To)
-	value := st.state.GetState(bvmEth, key)
+	value := st.state.GetState(BVM_ETH_ADDR, key)
 	bal := value.Big()
 	bal = bal.Add(bal, ethValue)
-	st.state.SetState(bvmEth, key, common.BigToHash(bal))
+	st.state.SetState(BVM_ETH_ADDR, key, common.BigToHash(bal))
 }
 
 func (st *StateTransition) addBVMETHTotalSupply(ethValue *big.Int) {
-	bvmEth := common.HexToAddress(BVM_ETH_ADDR)
 	key := getBVMETHTotalSupplyKey()
-	value := st.state.GetState(bvmEth, key)
+	value := st.state.GetState(BVM_ETH_ADDR, key)
 	bal := value.Big()
 	bal = bal.Add(bal, ethValue)
-	st.state.SetState(bvmEth, key, common.BigToHash(bal))
+	st.state.SetState(BVM_ETH_ADDR, key, common.BigToHash(bal))
 }
 
 func getBVMETHBalanceKey(addr common.Address) common.Hash {
@@ -578,7 +630,7 @@ func (st *StateTransition) generateBVMETHMintEvent(mintAddress common.Address, m
 	//data means the mint amount in MINT EVENT.
 	d := common.HexToHash(common.Bytes2Hex(mintValue.Bytes())).Bytes()
 	st.evm.StateDB.AddLog(&types.Log{
-		Address: common.HexToAddress(BVM_ETH_ADDR),
+		Address: BVM_ETH_ADDR,
 		Topics:  topics,
 		Data:    d,
 		// This is a non-consensus field, but assigned here because

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -482,7 +482,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 
 	// Check clauses 1-3, buy gas if everything is correct
-	tokenRatio := st.state.GetState(types.L1BlockAddr, types.TokenRatioSlot).Big().Uint64()
+	tokenRatio := st.state.GetState(types.GasOracleAddr, types.TokenRatioSlot).Big().Uint64()
 	l1Cost, err := st.preCheck()
 	if err != nil {
 		return nil, err

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -192,7 +192,7 @@ var DefaultConfig = Config{
 	Journal:   "transactions.rlp",
 	Rejournal: time.Hour,
 
-	PriceLimit: 1,
+	PriceLimit: 0,
 	PriceBump:  10,
 
 	AccountSlots: 16,
@@ -211,7 +211,7 @@ func (config *Config) sanitize() Config {
 		log.Warn("Sanitizing invalid txpool journal time", "provided", conf.Rejournal, "updated", time.Second)
 		conf.Rejournal = time.Second
 	}
-	if conf.PriceLimit < 1 {
+	if conf.PriceLimit < 0 {
 		log.Warn("Sanitizing invalid txpool price limit", "provided", conf.PriceLimit, "updated", DefaultConfig.PriceLimit)
 		conf.PriceLimit = DefaultConfig.PriceLimit
 	}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -745,7 +745,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return err
 	}
-	tokenRatio := pool.currentState.GetState(types.L1BlockAddr, types.TokenRatioSlot).Big().Uint64()
+	tokenRatio := pool.currentState.GetState(types.GasOracleAddr, types.TokenRatioSlot).Big().Uint64()
 
 	if tx.Gas() < intrGas*tokenRatio {
 		return core.ErrIntrinsicGas

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -675,7 +675,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrInvalidSender
 	}
 	// Drop non-local transactions under our own minimal accepted gas price or tip
-	if !local && tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
+	if tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -268,7 +268,7 @@ type TxPool struct {
 	pendingNonces *noncer        // Pending state tracking virtual nonces
 	currentMaxGas uint64         // Current gas limit for transaction caps
 
-	l1CostFn func(dataGas types.RollupGasData, isDepositTx bool) *big.Int // Current L1 fee cost function
+	l1CostFn func(dataGas types.RollupGasData, isDepositTx bool, to *common.Address) *big.Int // Current L1 fee cost function
 
 	locals  *accountSet // Set of local transaction to exempt from eviction rules
 	journal *journal    // Journal of local transaction to back up to disk
@@ -685,7 +685,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
 	cost := tx.Cost()
-	if l1Cost := pool.l1CostFn(tx.RollupDataGas(), tx.IsDepositTx()); l1Cost != nil { // add rollup cost
+	if l1Cost := pool.l1CostFn(tx.RollupDataGas(), tx.IsDepositTx(), tx.To()); l1Cost != nil { // add rollup cost
 		cost = cost.Add(cost, l1Cost)
 	}
 
@@ -729,7 +729,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		if repl := list.txs.Get(tx.Nonce()); repl != nil {
 			// Deduct the cost of a transaction replaced by this
 			replL1Cost := repl.Cost()
-			if l1Cost := pool.l1CostFn(tx.RollupDataGas(), tx.IsDepositTx()); l1Cost != nil { // add rollup cost
+			if l1Cost := pool.l1CostFn(tx.RollupDataGas(), tx.IsDepositTx(), tx.To()); l1Cost != nil { // add rollup cost
 				replL1Cost = replL1Cost.Add(cost, l1Cost)
 			}
 			sum.Sub(sum, replL1Cost)
@@ -1457,8 +1457,8 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	}
 
 	costFn := types.NewL1CostFunc(pool.chainconfig, statedb)
-	pool.l1CostFn = func(dataGas types.RollupGasData, isDepositTx bool) *big.Int {
-		return costFn(newHead.Number.Uint64(), newHead.Time, dataGas, isDepositTx)
+	pool.l1CostFn = func(dataGas types.RollupGasData, isDepositTx bool, to *common.Address) *big.Int {
+		return costFn(newHead.Number.Uint64(), newHead.Time, dataGas, isDepositTx, to)
 	}
 
 	// Inject any transactions discarded due to reorgs
@@ -1492,7 +1492,7 @@ func (pool *TxPool) validateMetaTxList(list *list) ([]*types.Transaction, *big.I
 			invalidMetaTxs = append(invalidMetaTxs, tx)
 		}
 		txGasCost := new(big.Int).Mul(tx.GasPrice(), new(big.Int).SetUint64(tx.Gas()))
-		l1Cost := pool.l1CostFn(tx.RollupDataGas(), tx.IsDepositTx())
+		l1Cost := pool.l1CostFn(tx.RollupDataGas(), tx.IsDepositTx(), tx.To())
 		if l1Cost != nil {
 			txGasCost = new(big.Int).Add(txGasCost, l1Cost) // gas fee sponsor must sponsor additional l1Cost fee
 		}
@@ -1538,7 +1538,7 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 		if !list.Empty() {
 			// Reduce the cost-cap by L1 rollup cost of the first tx if necessary. Other txs will get filtered out afterwards.
 			el := list.txs.FirstElement()
-			if l1Cost := pool.l1CostFn(el.RollupDataGas(), el.IsDepositTx()); l1Cost != nil {
+			if l1Cost := pool.l1CostFn(el.RollupDataGas(), el.IsDepositTx(), el.To()); l1Cost != nil {
 				balance = new(big.Int).Sub(balance, l1Cost) // negative big int is fine
 			}
 		}
@@ -1751,7 +1751,7 @@ func (pool *TxPool) demoteUnexecutables() {
 		if !list.Empty() {
 			// Reduce the cost-cap by L1 rollup cost of the first tx if necessary. Other txs will get filtered out afterwards.
 			el := list.txs.FirstElement()
-			if l1Cost := pool.l1CostFn(el.RollupDataGas(), el.IsDepositTx()); l1Cost != nil {
+			if l1Cost := pool.l1CostFn(el.RollupDataGas(), el.IsDepositTx(), el.To()); l1Cost != nil {
 				balance = new(big.Int).Sub(balance, l1Cost) // negative big int is fine
 			}
 		}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -704,7 +704,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 
 		sponsorBalance := pool.currentState.GetBalance(metaTxParams.GasFeeSponsor)
 		if sponsorBalance.Cmp(sponsorAmount) < 0 {
-			return core.ErrInsufficientFunds
+			return types.ErrSponsorBalanceNotEnough
 		}
 		selfBalance := pool.currentState.GetBalance(from)
 		if selfBalance.Cmp(selfPayAmount) < 0 {
@@ -745,7 +745,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return err
 	}
-	if tx.Gas() < intrGas {
+	tokenRatio := pool.currentState.GetState(types.L1BlockAddr, types.TokenRatioSlot).Big().Uint64()
+
+	if tx.Gas() < intrGas*tokenRatio {
 		return core.ErrIntrinsicGas
 	}
 	return nil

--- a/core/txpool/txpool2_test.go
+++ b/core/txpool/txpool2_test.go
@@ -17,15 +17,22 @@ package txpool
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+
+	"github.com/stretchr/testify/require"
 )
 
 func pricedValuedTransaction(nonce uint64, value int64, gaslimit uint64, gasprice *big.Int, key *ecdsa.PrivateKey) *types.Transaction {
@@ -209,4 +216,384 @@ func TestTransactionZAttack(t *testing.T) {
 		t.Errorf("Wrong invalid pending-count, have %d, want %d (GlobalSlots: %d, queued: %d)",
 			newIvPending, ivPending, pool.config.GlobalSlots, newQueued)
 	}
+}
+
+func decodeSignature(sig []byte) (r, s, v *big.Int) {
+	if len(sig) != crypto.SignatureLength {
+		panic(fmt.Sprintf("wrong size for signature: got %d, want %d", len(sig), crypto.SignatureLength))
+	}
+	r = new(big.Int).SetBytes(sig[:32])
+	s = new(big.Int).SetBytes(sig[32:64])
+	v = new(big.Int).SetBytes([]byte{sig[64] + 27})
+	return r, s, v
+}
+
+func generateMetaTxData(dynamicTx *types.DynamicFeeTx, expireHeight uint64, sponsorPercent uint64,
+	gasFeeSponsorAddr common.Address, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	metaTxSignData := &types.MetaTxSignData{
+		ChainID:        dynamicTx.ChainID,
+		Nonce:          dynamicTx.Nonce,
+		GasTipCap:      dynamicTx.GasTipCap,
+		GasFeeCap:      dynamicTx.GasFeeCap,
+		Gas:            dynamicTx.Gas,
+		To:             dynamicTx.To,
+		Value:          dynamicTx.Value,
+		Data:           dynamicTx.Data,
+		AccessList:     dynamicTx.AccessList,
+		ExpireHeight:   expireHeight,
+		SponsorPercent: sponsorPercent,
+	}
+
+	sponsorSig, err := crypto.Sign(metaTxSignData.Hash().Bytes(), privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	r, s, v := decodeSignature(sponsorSig)
+
+	metaTxData := &types.MetaTxParams{
+		ExpireHeight:   expireHeight,
+		Payload:        metaTxSignData.Data,
+		GasFeeSponsor:  gasFeeSponsorAddr,
+		SponsorPercent: sponsorPercent,
+		R:              r,
+		S:              s,
+		V:              v,
+	}
+
+	metaTxDataBz, err := rlp.EncodeToBytes(metaTxData)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(types.MetaTxPrefix, metaTxDataBz...), nil
+}
+
+// Tests that if invalid meta txs can be picked out and valid meta txs can be executed
+func TestMetaTx(t *testing.T) {
+	t.Parallel()
+	// Create the pool to test the pricing enforcement with
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := newTestBlockChain(10000000, statedb, new(event.Feed))
+	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
+	defer pool.Stop()
+
+	sponsorNum := 10
+	gasFeeSponsorPrivateKeys := make([]*ecdsa.PrivateKey, 0, sponsorNum)
+	gasFeeSponsorAddrs := make([]common.Address, 0, sponsorNum)
+	for i := 0; i < sponsorNum; i++ {
+		gasFeeSponsor, _ := crypto.GenerateKey()
+		gasFeeSponsorPrivateKeys = append(gasFeeSponsorPrivateKeys, gasFeeSponsor)
+		gasFeeSponsorAddrs = append(gasFeeSponsorAddrs, crypto.PubkeyToAddress(gasFeeSponsor.PublicKey))
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(gasFeeSponsor.PublicKey), new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1e4)))
+	}
+	userNum1 := 100
+	usersAccountsWithoutBalancePrivateKey := make([]*ecdsa.PrivateKey, 0, userNum1)
+	usersAccountsWithoutBalanceAddrs := make([]common.Address, 0, userNum1)
+	for i := 0; i < userNum1; i++ {
+		userAcc, _ := crypto.GenerateKey()
+		usersAccountsWithoutBalancePrivateKey = append(usersAccountsWithoutBalancePrivateKey, userAcc)
+		usersAccountsWithoutBalanceAddrs = append(usersAccountsWithoutBalanceAddrs, crypto.PubkeyToAddress(userAcc.PublicKey))
+	}
+
+	userNum2 := 10
+	usersAccountsWithBalancePrivateKey := make([]*ecdsa.PrivateKey, 0, userNum2)
+	usersAccountsWithBalanceAddrs := make([]common.Address, 0, userNum2)
+	for i := 0; i < userNum2; i++ {
+		userAcc, _ := crypto.GenerateKey()
+		usersAccountsWithBalancePrivateKey = append(usersAccountsWithBalancePrivateKey, userAcc)
+		usersAccountsWithBalanceAddrs = append(usersAccountsWithBalanceAddrs, crypto.PubkeyToAddress(userAcc.PublicKey))
+		pool.currentState.AddBalance(crypto.PubkeyToAddress(userAcc.PublicKey), new(big.Int).Mul(big.NewInt(1e18), big.NewInt(1)))
+	}
+
+	chainId := params.TestChainConfig.ChainID
+	signer := types.LatestSignerForChainID(chainId)
+	approveABICallData, _ := hexutil.Decode("0x095ea7b30000000000000000000000001f9090aae28b8a3dceadf281b0f12828e676c3260000000000000000000000000000000000000000000000000de0b6b3a7640000")
+	to := common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+	expireHeight := uint64(20_000_010)
+
+	userNonceMap := make(map[common.Address]uint64)
+	for i := 0; i < sponsorNum; i++ {
+		for j := 0; j < userNum1; j++ {
+			nonce := userNonceMap[usersAccountsWithoutBalanceAddrs[j]]
+			dynamicTx := &types.DynamicFeeTx{
+				ChainID:    chainId,
+				Nonce:      nonce,
+				GasTipCap:  big.NewInt(1e9),
+				GasFeeCap:  big.NewInt(2e9),
+				Gas:        4700000,
+				To:         &to,
+				Value:      big.NewInt(0),
+				Data:       approveABICallData,
+				AccessList: nil,
+			}
+			payload, err := generateMetaTxData(dynamicTx, expireHeight, 100, gasFeeSponsorAddrs[i], gasFeeSponsorPrivateKeys[i])
+			require.NoError(t, err)
+
+			dynamicTx.Data = payload
+			tx := types.NewTx(dynamicTx)
+
+			txSignature, err := crypto.Sign(signer.Hash(tx).Bytes(), usersAccountsWithoutBalancePrivateKey[j])
+			require.NoError(t, err)
+			signedTx, err := tx.WithSignature(signer, txSignature)
+			require.NoError(t, err)
+
+			err = pool.AddLocal(signedTx)
+			require.NoError(t, err)
+
+			userNonceMap[usersAccountsWithoutBalanceAddrs[j]] = nonce + 1
+		}
+	}
+
+	all := pool.all.Count()
+	pending, queued := pool.Stats()
+	if pending != userNum1*sponsorNum {
+		t.Errorf("Wrong pending-count, want %d, have %d",
+			userNum1*sponsorNum, pending)
+	}
+
+	// increase nonce so that later tx can only be included into txpool queue
+	for j := 0; j < userNum1; j++ {
+		userNonceMap[usersAccountsWithoutBalanceAddrs[j]] = userNonceMap[usersAccountsWithoutBalanceAddrs[j]] + 1
+	}
+
+	for i := 0; i < sponsorNum; i++ {
+		for j := 0; j < userNum1; j++ {
+			nonce := userNonceMap[usersAccountsWithoutBalanceAddrs[j]]
+			dynamicTx := &types.DynamicFeeTx{
+				ChainID:    chainId,
+				Nonce:      nonce,
+				GasTipCap:  big.NewInt(1e9),
+				GasFeeCap:  big.NewInt(2e9),
+				Gas:        4700000,
+				To:         &to,
+				Value:      big.NewInt(0),
+				Data:       approveABICallData,
+				AccessList: nil,
+			}
+			payload, err := generateMetaTxData(dynamicTx, expireHeight, 100, gasFeeSponsorAddrs[i], gasFeeSponsorPrivateKeys[i])
+			require.NoError(t, err)
+
+			dynamicTx.Data = payload
+			tx := types.NewTx(dynamicTx)
+
+			txSignature, err := crypto.Sign(signer.Hash(tx).Bytes(), usersAccountsWithoutBalancePrivateKey[j])
+			require.NoError(t, err)
+			signedTx, err := tx.WithSignature(signer, txSignature)
+			require.NoError(t, err)
+
+			err = pool.AddLocal(signedTx)
+			require.NoError(t, err)
+
+			userNonceMap[usersAccountsWithoutBalanceAddrs[j]] = nonce + 1
+		}
+	}
+
+	all = pool.all.Count()
+	pending, queued = pool.Stats()
+	if pending != userNum1*sponsorNum {
+		t.Errorf("Wrong pending-count, want %d, have %d",
+			userNum1*sponsorNum, pending)
+	}
+	if queued != userNum1*sponsorNum {
+		t.Errorf("Wrong queued-count, want %d, have %d",
+			userNum1*sponsorNum, pending)
+	}
+	if all != 2*userNum1*sponsorNum {
+		t.Errorf("Wrong queued-count, want %d, have %d",
+			2*userNum1*sponsorNum, all)
+	}
+
+	{
+		nonce := userNonceMap[usersAccountsWithoutBalanceAddrs[0]]
+		dynamicTx := &types.DynamicFeeTx{
+			ChainID:    chainId,
+			Nonce:      nonce,
+			GasTipCap:  big.NewInt(1e9),
+			GasFeeCap:  big.NewInt(2e9),
+			Gas:        4700000,
+			To:         &to,
+			Value:      big.NewInt(0),
+			Data:       approveABICallData,
+			AccessList: nil,
+		}
+		payload, err := generateMetaTxData(dynamicTx, expireHeight, 90, gasFeeSponsorAddrs[0], gasFeeSponsorPrivateKeys[0])
+		require.NoError(t, err)
+
+		dynamicTx.Data = payload
+		tx := types.NewTx(dynamicTx)
+
+		txSignature, err := crypto.Sign(signer.Hash(tx).Bytes(), usersAccountsWithoutBalancePrivateKey[0])
+		require.NoError(t, err)
+		signedTx, err := tx.WithSignature(signer, txSignature)
+		require.NoError(t, err)
+
+		err = pool.AddLocal(signedTx)
+		require.Equal(t, err, core.ErrInsufficientFunds)
+	}
+
+	for i := 0; i < sponsorNum; i++ {
+		for j := 0; j < userNum2; j++ {
+			nonce := userNonceMap[usersAccountsWithBalanceAddrs[j]]
+			dynamicTx := &types.DynamicFeeTx{
+				ChainID:    chainId,
+				Nonce:      nonce,
+				GasTipCap:  big.NewInt(1e9),
+				GasFeeCap:  big.NewInt(2e9),
+				Gas:        4700000,
+				To:         &to,
+				Value:      big.NewInt(0),
+				Data:       approveABICallData,
+				AccessList: nil,
+			}
+			payload, err := generateMetaTxData(dynamicTx, expireHeight, 90, gasFeeSponsorAddrs[i], gasFeeSponsorPrivateKeys[i])
+			require.NoError(t, err)
+
+			dynamicTx.Data = payload
+			tx := types.NewTx(dynamicTx)
+
+			txSignature, err := crypto.Sign(signer.Hash(tx).Bytes(), usersAccountsWithBalancePrivateKey[j])
+			require.NoError(t, err)
+			signedTx, err := tx.WithSignature(signer, txSignature)
+			require.NoError(t, err)
+
+			err = pool.AddLocal(signedTx)
+			require.NoError(t, err)
+
+			userNonceMap[usersAccountsWithBalanceAddrs[j]] = nonce + 1
+		}
+	}
+	all1 := pool.all.Count()
+	pending1, queued1 := pool.Stats()
+	if pending1-pending != userNum2*sponsorNum {
+		t.Errorf("Wrong pending-count delta, want %d, have %d",
+			userNum2*sponsorNum, pending1-pending)
+	}
+	if queued1-queued != 0 {
+		t.Errorf("Wrong queued-count delta, want %d, have %d",
+			0, queued1-queued)
+	}
+	if all1-all != userNum2*sponsorNum {
+		t.Errorf("Wrong queued-count delta, want %d, have %d",
+			userNum2*sponsorNum, all1-all)
+	}
+}
+
+// Tests there are meta txs and normal txs from the same user
+func TestMixedMetaTxs(t *testing.T) {
+	t.Parallel()
+	// Create the pool to test the pricing enforcement with
+	statedb, _ := state.New(common.Hash{}, state.NewDatabase(rawdb.NewMemoryDatabase()), nil)
+	blockchain := newTestBlockChain(10000000, statedb, new(event.Feed))
+	pool := NewTxPool(testTxPoolConfig, eip1559Config, blockchain)
+	defer pool.Stop()
+
+	gasFeeSponsorPrivateKey, _ := crypto.GenerateKey()
+	gasFeeSponsorAddr := crypto.PubkeyToAddress(gasFeeSponsorPrivateKey.PublicKey)
+
+	userAccPrivateKey, _ := crypto.GenerateKey()
+	userAccAddr := crypto.PubkeyToAddress(userAccPrivateKey.PublicKey)
+
+	pool.currentState.AddBalance(gasFeeSponsorAddr, big.NewInt(1e18))
+	pool.currentState.AddBalance(userAccAddr, big.NewInt(188e14))
+
+	chainId := params.TestChainConfig.ChainID
+	signer := types.LatestSignerForChainID(chainId)
+	approveABICallData, _ := hexutil.Decode("0x095ea7b30000000000000000000000001f9090aae28b8a3dceadf281b0f12828e676c3260000000000000000000000000000000000000000000000000de0b6b3a7640000")
+	to := common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+	expireHeight := uint64(20_000_010)
+
+	nonce := uint64(0)
+
+	dynamicTx := &types.DynamicFeeTx{
+		ChainID:    chainId,
+		Nonce:      nonce,
+		GasTipCap:  big.NewInt(1e9),
+		GasFeeCap:  big.NewInt(2e9),
+		Gas:        4700000,
+		To:         &to,
+		Value:      big.NewInt(0),
+		Data:       approveABICallData,
+		AccessList: nil,
+	}
+	tx := types.NewTx(dynamicTx)
+	txSignature, err := crypto.Sign(signer.Hash(tx).Bytes(), userAccPrivateKey)
+	require.NoError(t, err)
+	signedTx, err := tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+	err = pool.AddLocal(signedTx)
+	require.NoError(t, err)
+	nonce++
+
+	dynamicTx = &types.DynamicFeeTx{
+		ChainID:    chainId,
+		Nonce:      nonce,
+		GasTipCap:  big.NewInt(1e9),
+		GasFeeCap:  big.NewInt(2e9),
+		Gas:        470000,
+		To:         &to,
+		Value:      big.NewInt(0),
+		Data:       approveABICallData,
+		AccessList: nil,
+	}
+	payload, err := generateMetaTxData(dynamicTx, expireHeight, 100, gasFeeSponsorAddr, gasFeeSponsorPrivateKey)
+	require.NoError(t, err)
+	dynamicTx.Data = payload
+	tx = types.NewTx(dynamicTx)
+	txSignature, err = crypto.Sign(signer.Hash(tx).Bytes(), userAccPrivateKey)
+	require.NoError(t, err)
+	signedTx, err = tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+	err = pool.AddLocal(signedTx)
+	require.NoError(t, err)
+	nonce++
+
+	dynamicTx = &types.DynamicFeeTx{
+		ChainID:    chainId,
+		Nonce:      nonce,
+		GasTipCap:  big.NewInt(1e9),
+		GasFeeCap:  big.NewInt(2e9),
+		Gas:        470000,
+		To:         &to,
+		Value:      big.NewInt(0),
+		Data:       approveABICallData,
+		AccessList: nil,
+	}
+	payload, err = generateMetaTxData(dynamicTx, expireHeight, 100, gasFeeSponsorAddr, gasFeeSponsorPrivateKey)
+	require.NoError(t, err)
+	dynamicTx.Data = payload
+	tx = types.NewTx(dynamicTx)
+	txSignature, err = crypto.Sign(signer.Hash(tx).Bytes(), userAccPrivateKey)
+	require.NoError(t, err)
+	signedTx, err = tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+	err = pool.AddLocal(signedTx)
+	require.NoError(t, err)
+	nonce++
+
+	pending, _ := pool.Stats()
+	require.Equal(t, 3, pending)
+
+	dynamicTx = &types.DynamicFeeTx{
+		ChainID:    chainId,
+		Nonce:      nonce,
+		GasTipCap:  big.NewInt(1e9),
+		GasFeeCap:  big.NewInt(2e9),
+		Gas:        4700000,
+		To:         &to,
+		Value:      big.NewInt(0),
+		Data:       approveABICallData,
+		AccessList: nil,
+	}
+	tx = types.NewTx(dynamicTx)
+	txSignature, err = crypto.Sign(signer.Hash(tx).Bytes(), userAccPrivateKey)
+	require.NoError(t, err)
+	signedTx, err = tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+	err = pool.AddLocal(signedTx)
+	require.NoError(t, err)
+	nonce++
+
+	pending, _ = pool.Stats()
+	require.Equal(t, 4, pending)
 }

--- a/core/types/deposit_tx.go
+++ b/core/types/deposit_tx.go
@@ -39,6 +39,8 @@ type DepositTx struct {
 	Gas uint64
 	// Field indicating if this transaction is exempt from the L2 gas limit.
 	IsSystemTransaction bool
+	// EthValue means L2 BVM_ETH mint tag, nil means that there is no need to mint BVM_ETH.
+	EthValue *big.Int `rlp:"nil"`
 	// Normal Tx data
 	Data []byte
 }
@@ -54,12 +56,16 @@ func (tx *DepositTx) copy() TxData {
 		Gas:                 tx.Gas,
 		IsSystemTransaction: tx.IsSystemTransaction,
 		Data:                common.CopyBytes(tx.Data),
+		EthValue:            nil,
 	}
 	if tx.Mint != nil {
 		cpy.Mint = new(big.Int).Set(tx.Mint)
 	}
 	if tx.Value != nil {
 		cpy.Value.Set(tx.Value)
+	}
+	if tx.EthValue != nil {
+		cpy.EthValue = new(big.Int).Set(tx.EthValue)
 	}
 	return cpy
 }

--- a/core/types/gen_receipt_json.go
+++ b/core/types/gen_receipt_json.go
@@ -33,6 +33,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 		L1GasUsed         *hexutil.Big   `json:"l1GasUsed,omitempty"`
 		L1Fee             *hexutil.Big   `json:"l1Fee,omitempty"`
 		FeeScalar         *big.Float     `json:"l1FeeScalar,omitempty"`
+		TokenRatio        *hexutil.Big   `json:"tokenRatio,omitempty"`
 	}
 	var enc Receipt
 	enc.Type = hexutil.Uint64(r.Type)
@@ -52,6 +53,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	enc.L1GasUsed = (*hexutil.Big)(r.L1GasUsed)
 	enc.L1Fee = (*hexutil.Big)(r.L1Fee)
 	enc.FeeScalar = r.FeeScalar
+	enc.TokenRatio = (*hexutil.Big)(r.TokenRatio)
 	return json.Marshal(&enc)
 }
 
@@ -76,6 +78,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 		L1Fee             *hexutil.Big    `json:"l1Fee,omitempty"`
 		FeeScalar         *big.Float      `json:"l1FeeScalar,omitempty"`
 		DepositNonce      *hexutil.Uint64 `json:"depositNonce,omitempty"`
+		TokenRatio        *hexutil.Big    `json:"tokenRatio,omitempty"`
 	}
 	var dec Receipt
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -139,6 +142,9 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	}
 	if dec.DepositNonce != nil {
 		r.DepositNonce = (*uint64)(dec.DepositNonce)
+	}
+	if dec.TokenRatio != nil {
+		r.TokenRatio = (*big.Int)(dec.TokenRatio)
 	}
 	return nil
 }

--- a/core/types/meta_transaction.go
+++ b/core/types/meta_transaction.go
@@ -1,0 +1,151 @@
+package types
+
+import (
+	"bytes"
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+const (
+	MetaTxPrefixLength = 32
+	OneHundredPercent  = 100
+)
+
+var (
+	// ASCII code of "MantleMetaTxPrefix"
+	MetaTxPrefix, _ = hexutil.Decode("0x00000000000000000000000000004D616E746C654D6574615478507265666978")
+
+	ErrExpiredMetaTx           = errors.New("expired meta transaction")
+	ErrInvalidGasFeeSponsorSig = errors.New("invalid gas fee sponsor signature")
+	ErrGasFeeSponsorMismatch   = errors.New("gas fee sponsor address is mismatch with signature")
+	ErrInvalidSponsorPercent   = errors.New("invalid sponsor percent, expected range [0, 100]")
+)
+
+type MetaTxParams struct {
+	ExpireHeight   uint64
+	SponsorPercent uint64
+	Payload        []byte
+
+	// In tx simulation, Signature will be empty, user can specify GasFeeSponsor to sponsor gas fee
+	GasFeeSponsor common.Address
+	// Signature values
+	V *big.Int
+	R *big.Int
+	S *big.Int
+}
+
+type MetaTxParamsCache struct {
+	metaTxParams *MetaTxParams
+}
+
+type MetaTxSignData struct {
+	ChainID        *big.Int
+	Nonce          uint64
+	GasTipCap      *big.Int
+	GasFeeCap      *big.Int
+	Gas            uint64
+	To             *common.Address `rlp:"nil"`
+	Value          *big.Int
+	Data           []byte
+	AccessList     AccessList
+	ExpireHeight   uint64
+	SponsorPercent uint64
+}
+
+func CalculateSponsorPercentAmount(mxParams *MetaTxParams, amount *big.Int) (*big.Int, *big.Int) {
+	if mxParams == nil {
+		return nil, nil
+	}
+	sponsorAmount := new(big.Int).Div(
+		new(big.Int).Mul(amount, big.NewInt(int64(mxParams.SponsorPercent))),
+		big.NewInt(OneHundredPercent))
+	selfAmount := new(big.Int).Sub(amount, sponsorAmount)
+	return sponsorAmount, selfAmount
+}
+
+func DecodeMetaTxParams(txData []byte) (*MetaTxParams, error) {
+	if len(txData) <= len(MetaTxPrefix) {
+		return nil, nil
+	}
+	if !bytes.Equal(txData[:MetaTxPrefixLength], MetaTxPrefix) {
+		return nil, nil
+	}
+
+	var metaTxParams MetaTxParams
+	err := rlp.DecodeBytes(txData[MetaTxPrefixLength:], &metaTxParams)
+	if err != nil {
+		return nil, err
+	}
+
+	if metaTxParams.SponsorPercent > OneHundredPercent {
+		return nil, ErrInvalidSponsorPercent
+	}
+
+	return &metaTxParams, nil
+}
+
+func DecodeAndVerifyMetaTxParams(tx *Transaction) (*MetaTxParams, error) {
+	if tx.Type() != DynamicFeeTxType {
+		return nil, nil
+	}
+
+	if mtp := tx.metaTxParams.Load(); mtp != nil {
+		mtpCache, ok := mtp.(*MetaTxParamsCache)
+		if ok {
+			return mtpCache.metaTxParams, nil
+		}
+	}
+
+	metaTxParams, err := DecodeMetaTxParams(tx.Data())
+	if err != nil {
+		return nil, err
+	}
+	// Not metaTx
+	if metaTxParams == nil {
+		tx.metaTxParams.Store(&MetaTxParamsCache{
+			metaTxParams: nil,
+		})
+		return nil, nil
+	}
+
+	if metaTxParams.SponsorPercent > OneHundredPercent {
+		return nil, ErrInvalidSponsorPercent
+	}
+
+	metaTxSignData := &MetaTxSignData{
+		ChainID:        tx.ChainId(),
+		Nonce:          tx.Nonce(),
+		GasTipCap:      tx.GasTipCap(),
+		GasFeeCap:      tx.GasFeeCap(),
+		Gas:            tx.Gas(),
+		To:             tx.To(),
+		Value:          tx.Value(),
+		Data:           metaTxParams.Payload,
+		AccessList:     tx.AccessList(),
+		ExpireHeight:   metaTxParams.ExpireHeight,
+		SponsorPercent: metaTxParams.SponsorPercent,
+	}
+
+	gasFeeSponsorSigner, err := recoverPlain(metaTxSignData.Hash(), metaTxParams.R, metaTxParams.S, metaTxParams.V, true)
+	if err != nil {
+		return nil, ErrInvalidGasFeeSponsorSig
+	}
+
+	if gasFeeSponsorSigner != metaTxParams.GasFeeSponsor {
+		return nil, ErrGasFeeSponsorMismatch
+	}
+
+	tx.metaTxParams.Store(&MetaTxParamsCache{
+		metaTxParams: metaTxParams,
+	})
+
+	return metaTxParams, nil
+}
+
+func (metaTxSignData *MetaTxSignData) Hash() common.Hash {
+	return rlpHash(metaTxSignData)
+}

--- a/core/types/meta_transaction.go
+++ b/core/types/meta_transaction.go
@@ -23,6 +23,7 @@ var (
 	ErrInvalidGasFeeSponsorSig = errors.New("invalid gas fee sponsor signature")
 	ErrGasFeeSponsorMismatch   = errors.New("gas fee sponsor address is mismatch with signature")
 	ErrInvalidSponsorPercent   = errors.New("invalid sponsor percent, expected range [0, 100]")
+	ErrSponsorBalanceNotEnough = errors.New("sponsor doesn't have enough balance")
 )
 
 type MetaTxParams struct {

--- a/core/types/meta_transaction_test.go
+++ b/core/types/meta_transaction_test.go
@@ -1,0 +1,243 @@
+package types
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	userKey, _           = crypto.HexToECDSA("eef77acb6c6a6eebc5b363a475ac583ec7eccdb42b6481424c60f59aa326547f")
+	gasFeeSponsorKey1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	gasFeeSponsorKey2, _ = crypto.HexToECDSA("0288ef00023598499cb6c940146d050d2b1fb914198c327f76aad590bead68b6")
+)
+
+func generateMetaTxData(dynamicTx *DynamicFeeTx, expireHeight uint64, sponsorPercent uint64,
+	gasFeeSponsorAddr common.Address, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	metaTxSignData := &MetaTxSignData{
+		ChainID:        dynamicTx.ChainID,
+		Nonce:          dynamicTx.Nonce,
+		GasTipCap:      dynamicTx.GasTipCap,
+		GasFeeCap:      dynamicTx.GasFeeCap,
+		Gas:            dynamicTx.Gas,
+		To:             dynamicTx.To,
+		Value:          dynamicTx.Value,
+		Data:           dynamicTx.Data,
+		AccessList:     dynamicTx.AccessList,
+		ExpireHeight:   expireHeight,
+		SponsorPercent: sponsorPercent,
+	}
+
+	sponsorSig, err := crypto.Sign(metaTxSignData.Hash().Bytes(), privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	r, s, v := decodeSignature(sponsorSig)
+
+	metaTxData := &MetaTxParams{
+		ExpireHeight:   expireHeight,
+		Payload:        metaTxSignData.Data,
+		GasFeeSponsor:  gasFeeSponsorAddr,
+		SponsorPercent: sponsorPercent,
+		R:              r,
+		S:              s,
+		V:              v,
+	}
+
+	metaTxDataBz, err := rlp.EncodeToBytes(metaTxData)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(MetaTxPrefix, metaTxDataBz...), nil
+}
+
+func generateMetaTxDataWithMockSig(dynamicTx *DynamicFeeTx, expireHeight uint64, sponsorPercent uint64,
+	gasFeeSponsorAddr common.Address, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	metaTxSignData := &MetaTxSignData{
+		ChainID:        dynamicTx.ChainID,
+		Nonce:          dynamicTx.Nonce,
+		GasTipCap:      dynamicTx.GasTipCap,
+		GasFeeCap:      dynamicTx.GasFeeCap,
+		Gas:            dynamicTx.Gas,
+		To:             dynamicTx.To,
+		Value:          dynamicTx.Value,
+		Data:           dynamicTx.Data,
+		AccessList:     dynamicTx.AccessList,
+		ExpireHeight:   expireHeight,
+		SponsorPercent: sponsorPercent,
+	}
+
+	sponsorSig, err := crypto.Sign(metaTxSignData.Hash().Bytes(), privateKey)
+	if err != nil {
+		return nil, err
+	}
+
+	sponsorSig[len(sponsorSig)-1] = sponsorSig[len(sponsorSig)-1] + 2
+
+	r, s, v := decodeSignature(sponsorSig)
+	metaTxData := &MetaTxParams{
+		ExpireHeight:   expireHeight,
+		Payload:        metaTxSignData.Data,
+		GasFeeSponsor:  gasFeeSponsorAddr,
+		SponsorPercent: sponsorPercent,
+		R:              r,
+		S:              s,
+		V:              v,
+	}
+
+	metaTxDataBz, err := rlp.EncodeToBytes(metaTxData)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(MetaTxPrefix, metaTxDataBz...), nil
+}
+
+func TestDecodeMetaTxParams(t *testing.T) {
+	gasFeeSponsorPublicKey := gasFeeSponsorKey1.Public()
+	pubKeyECDSA, _ := gasFeeSponsorPublicKey.(*ecdsa.PublicKey)
+	gasFeeSponsorAddr := crypto.PubkeyToAddress(*pubKeyECDSA)
+
+	chainId := big.NewInt(1)
+	depositABICalldata, _ := hexutil.Decode("0xd0e30db0")
+	to := common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+	expireHeight := uint64(20_000_010)
+	dynamicTx := &DynamicFeeTx{
+		ChainID:    chainId,
+		Nonce:      100,
+		GasTipCap:  big.NewInt(1e9),
+		GasFeeCap:  big.NewInt(1e15),
+		Gas:        4700000,
+		To:         &to,
+		Value:      big.NewInt(1e18),
+		Data:       depositABICalldata,
+		AccessList: nil,
+	}
+
+	metaTxData := &MetaTxParams{
+		ExpireHeight:   expireHeight,
+		Payload:        depositABICalldata,
+		GasFeeSponsor:  gasFeeSponsorAddr,
+		SponsorPercent: 50,
+	}
+
+	metaTxDataBz, err := rlp.EncodeToBytes(metaTxData)
+	require.NoError(t, err)
+
+	dynamicTx.Data = append(MetaTxPrefix, metaTxDataBz...)
+
+	metaTxParams, err := DecodeMetaTxParams(dynamicTx.Data)
+	require.NoError(t, err)
+
+	require.Equal(t, gasFeeSponsorAddr.String(), metaTxParams.GasFeeSponsor.String())
+	require.Equal(t, hexutil.Encode(depositABICalldata), hexutil.Encode(metaTxParams.Payload))
+
+	metaTxData = &MetaTxParams{
+		ExpireHeight:   expireHeight,
+		Payload:        depositABICalldata,
+		GasFeeSponsor:  gasFeeSponsorAddr,
+		SponsorPercent: 101,
+	}
+
+	metaTxDataBz, err = rlp.EncodeToBytes(metaTxData)
+	require.NoError(t, err)
+
+	dynamicTx.Data = append(MetaTxPrefix, metaTxDataBz...)
+
+	metaTxParams, err = DecodeMetaTxParams(dynamicTx.Data)
+	require.Equal(t, ErrInvalidSponsorPercent, err)
+
+}
+
+func TestDecodeAndVerifyMetaTxParams(t *testing.T) {
+	gasFeeSponsorPublicKey := gasFeeSponsorKey1.Public()
+	pubKeyECDSA, _ := gasFeeSponsorPublicKey.(*ecdsa.PublicKey)
+	gasFeeSponsorAddr := crypto.PubkeyToAddress(*pubKeyECDSA)
+
+	chainId := big.NewInt(1)
+	depositABICalldata, _ := hexutil.Decode("0xd0e30db0")
+	to := common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+	expireHeight := uint64(20_000_010)
+	dynamicTx := &DynamicFeeTx{
+		ChainID:    chainId,
+		Nonce:      100,
+		GasTipCap:  big.NewInt(1e9),
+		GasFeeCap:  big.NewInt(1e15),
+		Gas:        4700000,
+		To:         &to,
+		Value:      big.NewInt(1e18),
+		Data:       depositABICalldata,
+		AccessList: nil,
+	}
+
+	payload, err := generateMetaTxData(dynamicTx, expireHeight, 50, gasFeeSponsorAddr, gasFeeSponsorKey1)
+	require.NoError(t, err)
+
+	dynamicTx.Data = payload
+	tx := NewTx(dynamicTx)
+	signer := LatestSignerForChainID(chainId)
+	txSignature, err := crypto.Sign(signer.Hash(tx).Bytes(), userKey)
+	require.NoError(t, err)
+	signedTx, err := tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+
+	// test normal metaTx
+	metaTxParams, err := DecodeAndVerifyMetaTxParams(signedTx)
+	require.NoError(t, err)
+
+	require.Equal(t, gasFeeSponsorAddr.String(), metaTxParams.GasFeeSponsor.String())
+	require.Equal(t, hexutil.Encode(depositABICalldata), hexutil.Encode(metaTxParams.Payload))
+
+	// Test ErrInvalidGasFeeSponsorSig
+	dynamicTx.Data = depositABICalldata
+	payload, err = generateMetaTxDataWithMockSig(dynamicTx, expireHeight, 100, gasFeeSponsorAddr, gasFeeSponsorKey1)
+	require.NoError(t, err)
+
+	dynamicTx.Data = payload
+	tx = NewTx(dynamicTx)
+	txSignature, err = crypto.Sign(signer.Hash(tx).Bytes(), userKey)
+	require.NoError(t, err)
+	signedTx, err = tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+
+	_, err = DecodeAndVerifyMetaTxParams(signedTx)
+	require.Equal(t, err, ErrInvalidGasFeeSponsorSig)
+
+	// Test ErrGasFeeSponsorMismatch
+	dynamicTx.Data = depositABICalldata
+	payload, err = generateMetaTxData(dynamicTx, expireHeight, 80, gasFeeSponsorAddr, gasFeeSponsorKey2)
+	require.NoError(t, err)
+
+	dynamicTx.Data = payload
+	tx = NewTx(dynamicTx)
+	txSignature, err = crypto.Sign(signer.Hash(tx).Bytes(), userKey)
+	require.NoError(t, err)
+	signedTx, err = tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+
+	_, err = DecodeAndVerifyMetaTxParams(signedTx)
+	require.Equal(t, err, ErrGasFeeSponsorMismatch)
+
+	// Test ErrGasFeeSponsorMismatch
+	dynamicTx.Data = depositABICalldata
+	payload, err = generateMetaTxData(dynamicTx, expireHeight, 101, gasFeeSponsorAddr, gasFeeSponsorKey2)
+	require.NoError(t, err)
+
+	dynamicTx.Data = payload
+	tx = NewTx(dynamicTx)
+	txSignature, err = crypto.Sign(signer.Hash(tx).Bytes(), userKey)
+	require.NoError(t, err)
+	signedTx, err = tx.WithSignature(signer, txSignature)
+	require.NoError(t, err)
+
+	_, err = DecodeAndVerifyMetaTxParams(signedTx)
+	require.Equal(t, err, ErrInvalidSponsorPercent)
+}

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -147,6 +147,12 @@ type LegacyOptimismStoredReceiptRLP struct {
 	L1GasPrice        *big.Int
 	L1Fee             *big.Int
 	FeeScalar         string
+
+	// DAGasUsed,DAGasPrice,DAFee These values are not used to collect fee,
+	// so decode from ledger, but not exposed outside.
+	DAGasUsed  *big.Int
+	DAGasPrice *big.Int
+	DAFee      *big.Int
 }
 
 // LogForStorage is a wrapper around a Log that handles

--- a/core/types/rollup_l1_cost.go
+++ b/core/types/rollup_l1_cost.go
@@ -46,38 +46,74 @@ type StateGetter interface {
 type L1CostFunc func(blockNum uint64, blockTime uint64, dataGas RollupGasData, isDepositTx bool) *big.Int
 
 var (
-	L1BaseFeeSlot = common.BigToHash(big.NewInt(1))
-	OverheadSlot  = common.BigToHash(big.NewInt(5))
-	ScalarSlot    = common.BigToHash(big.NewInt(6))
+	L1BaseFeeSlot  = common.BigToHash(big.NewInt(1))
+	OverheadSlot   = common.BigToHash(big.NewInt(5))
+	ScalarSlot     = common.BigToHash(big.NewInt(6))
+	TokenRatioSlot = common.BigToHash(big.NewInt(0))
 )
 
-var L1BlockAddr = common.HexToAddress("0x4200000000000000000000000000000000000015")
+var (
+	L1BlockAddr   = common.HexToAddress("0x4200000000000000000000000000000000000015")
+	GasOracleAddr = common.HexToAddress("0x420000000000000000000000000000000000000F")
+	Decimals      = big.NewInt(1_000_000)
+)
 
 // NewL1CostFunc returns a function used for calculating L1 fee cost.
 // This depends on the oracles because gas costs can change over time.
 // It returns nil if there is no applicable cost function.
 func NewL1CostFunc(config *params.ChainConfig, statedb StateGetter) L1CostFunc {
 	cacheBlockNum := ^uint64(0)
-	var l1BaseFee, overhead, scalar *big.Int
+	var l1BaseFee, overhead, scalar, tokenRatio *big.Int
 	return func(blockNum uint64, blockTime uint64, dataGas RollupGasData, isDepositTx bool) *big.Int {
 		rollupDataGas := dataGas.DataGas(blockTime, config) // Only fake txs for RPC view-calls are 0.
 		if config.Optimism == nil || isDepositTx || rollupDataGas == 0 {
-			return nil
+			return common.Big0
 		}
 		if blockNum != cacheBlockNum {
 			l1BaseFee = statedb.GetState(L1BlockAddr, L1BaseFeeSlot).Big()
 			overhead = statedb.GetState(L1BlockAddr, OverheadSlot).Big()
 			scalar = statedb.GetState(L1BlockAddr, ScalarSlot).Big()
+			tokenRatio = statedb.GetState(GasOracleAddr, TokenRatioSlot).Big()
 			cacheBlockNum = blockNum
 		}
-		return L1Cost(rollupDataGas, l1BaseFee, overhead, scalar)
+		return L1Cost(rollupDataGas, l1BaseFee, overhead, scalar, tokenRatio)
 	}
 }
 
-func L1Cost(rollupDataGas uint64, l1BaseFee, overhead, scalar *big.Int) *big.Int {
+func L1Cost(rollupDataGas uint64, l1BaseFee, overhead, scalar, tokenRatio *big.Int) *big.Int {
 	l1GasUsed := new(big.Int).SetUint64(rollupDataGas)
 	l1GasUsed = l1GasUsed.Add(l1GasUsed, overhead)
 	l1Cost := l1GasUsed.Mul(l1GasUsed, l1BaseFee)
 	l1Cost = l1Cost.Mul(l1Cost, scalar)
-	return l1Cost.Div(l1Cost, big.NewInt(1_000_000))
+	l1Cost = l1Cost.Mul(l1Cost, tokenRatio)
+	return l1Cost.Div(l1Cost, Decimals)
+}
+
+// DeriveL1GasInfo reads L1 gas related information to be included
+// on the receipt
+func DeriveL1GasInfo(state StateGetter) (*big.Int, *big.Int, *big.Int, *big.Float, *big.Int) {
+	l1BaseFee, overhead, scalar, scaled := readL1BlockStorageSlots(L1BlockAddr, state)
+	tokenRatio := readGPOStorageSlots(GasOracleAddr, state)
+	return l1BaseFee, overhead, scalar, scaled, tokenRatio
+}
+
+func readL1BlockStorageSlots(addr common.Address, state StateGetter) (*big.Int, *big.Int, *big.Int, *big.Float) {
+	l1BaseFee := state.GetState(addr, L1BaseFeeSlot)
+	overhead := state.GetState(addr, OverheadSlot)
+	scalar := state.GetState(addr, ScalarSlot)
+	scaled := scaleDecimals(scalar.Big(), Decimals)
+	return l1BaseFee.Big(), overhead.Big(), scalar.Big(), scaled
+}
+
+func readGPOStorageSlots(addr common.Address, state StateGetter) *big.Int {
+	tokenRatio := state.GetState(addr, TokenRatioSlot)
+	return tokenRatio.Big()
+}
+
+// scaleDecimals will scale a value by decimals
+func scaleDecimals(scalar, divisor *big.Int) *big.Float {
+	fscalar := new(big.Float).SetInt(scalar)
+	fdivisor := new(big.Float).SetInt(divisor)
+	// fscalar / fdivisor
+	return new(big.Float).Quo(fscalar, fdivisor)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -58,6 +58,8 @@ type Transaction struct {
 	size atomic.Value
 	from atomic.Value
 
+	metaTxParams atomic.Value
+
 	// cache of RollupGasData details to compute the gas the tx takes on L1 for its share of rollup data
 	rollupGas atomic.Value
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -326,11 +326,20 @@ func (tx *Transaction) SourceHash() common.Hash {
 	return common.Hash{}
 }
 
-// Mint returns the ETH to mint in the deposit tx.
+// Mint returns the MNT to mint in the deposit tx.
 // This returns nil if there is nothing to mint, or if this is not a deposit tx.
 func (tx *Transaction) Mint() *big.Int {
 	if dep, ok := tx.inner.(*DepositTx); ok {
 		return dep.Mint
+	}
+	return nil
+}
+
+// ETHValue returns the BVM_ETH to mint in the deposit tx.
+// This returns nil if there is nothing to mint, or if this is not a deposit tx.
+func (tx *Transaction) ETHValue() *big.Int {
+	if dep, ok := tx.inner.(*DepositTx); ok {
+		return dep.EthValue
 	}
 	return nil
 }

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -48,6 +48,7 @@ type txJSON struct {
 	SourceHash *common.Hash    `json:"sourceHash,omitempty"`
 	From       *common.Address `json:"from,omitempty"`
 	Mint       *hexutil.Big    `json:"mint,omitempty"`
+	EthValue   *hexutil.Big    `json:"ethValue,omitempty"`
 	IsSystemTx *bool           `json:"isSystemTx,omitempty"`
 
 	// Access list transaction fields:
@@ -111,6 +112,9 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		enc.From = &itx.From
 		if itx.Mint != nil {
 			enc.Mint = (*hexutil.Big)(itx.Mint)
+		}
+		if itx.EthValue != nil {
+			enc.EthValue = (*hexutil.Big)(itx.EthValue)
 		}
 		enc.IsSystemTx = &itx.IsSystemTransaction
 		// other fields will show up as null.
@@ -310,6 +314,8 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		itx.Value = (*big.Int)(dec.Value)
 		// mint may be omitted or nil if there is nothing to mint.
 		itx.Mint = (*big.Int)(dec.Mint)
+		// ethValue may be omitted or nil if there is nothing to mint.
+		itx.EthValue = (*big.Int)(dec.EthValue)
 		if dec.Data == nil {
 			return errors.New("missing required field 'input' in transaction")
 		}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -57,6 +57,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	// If jump table was not initialised we set the default one.
 	var table *JumpTable
 	switch {
+	case evm.chainRules.IsMantleBaseFee:
+		table = &PUSH0InstructionSet
 	case evm.chainRules.IsShanghai:
 		table = &shanghaiInstructionSet
 	case evm.chainRules.IsMerge:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -56,6 +56,7 @@ var (
 	londonInstructionSet           = newLondonInstructionSet()
 	mergeInstructionSet            = newMergeInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
+	PUSH0InstructionSet            = newPUSH0InstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
@@ -77,6 +78,13 @@ func validate(jt JumpTable) JumpTable {
 		}
 	}
 	return jt
+}
+
+func newPUSH0InstructionSet() JumpTable {
+	instructionSet := newMergeInstructionSet()
+	enable3855(&instructionSet) // PUSH0 instruction
+	enable3860(&instructionSet) // Limit and meter initcode
+	return validate(instructionSet)
 }
 
 func newShanghaiInstructionSet() JumpTable {

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -17,10 +17,10 @@
 package runtime
 
 import (
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -74,7 +74,7 @@ func setDefaults(cfg *Config) {
 		cfg.Difficulty = new(big.Int)
 	}
 	if cfg.GasLimit == 0 {
-		cfg.GasLimit = math.MaxUint64
+		cfg.GasLimit = core.DefaultMantleBlockGasLimit
 	}
 	if cfg.GasPrice == nil {
 		cfg.GasPrice = new(big.Int)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -exu
+
+VERBOSITY=${GETH_VERBOSITY:-3}
+GETH_DATA_DIR=/db
+GETH_CHAINDATA_DIR="$GETH_DATA_DIR/geth/chaindata"
+GETH_KEYSTORE_DIR="$GETH_DATA_DIR/keystore"
+GENESIS_FILE_PATH="${GENESIS_FILE_PATH:-/genesis.json}"
+CHAIN_ID=$(cat "$GENESIS_FILE_PATH" | jq -r .config.chainId)
+BLOCK_SIGNER_PRIVATE_KEY=$BLOCK_SIGNER_PRIVATE_KEY
+BLOCK_SIGNER_ADDRESS=$BLOCK_SIGNER_ADDRESS
+RPC_PORT="${RPC_PORT:-8545}"
+WS_PORT="${WS_PORT:-8546}"
+
+if [ ! -d "$GETH_KEYSTORE_DIR" ]; then
+	echo "$GETH_KEYSTORE_DIR missing, running account import"
+	echo -n "pwd" > "$GETH_DATA_DIR"/password
+	echo -n "$BLOCK_SIGNER_PRIVATE_KEY" | sed 's/0x//' > "$GETH_DATA_DIR"/block-signer-key
+	geth account import \
+		--datadir="$GETH_DATA_DIR" \
+		--password="$GETH_DATA_DIR"/password \
+		"$GETH_DATA_DIR"/block-signer-key
+else
+	echo "$GETH_KEYSTORE_DIR exists."
+fi
+
+if [ ! -d "$GETH_CHAINDATA_DIR" ]; then
+	echo "$GETH_CHAINDATA_DIR missing, running init"
+	echo "Initializing genesis."
+	geth --verbosity="$VERBOSITY" init \
+		--datadir="$GETH_DATA_DIR" \
+		"$GENESIS_FILE_PATH"
+else
+	echo "$GETH_CHAINDATA_DIR exists."
+fi
+
+# Warning: Archive mode is required, otherwise old trie nodes will be
+# pruned within minutes of starting the devnet.
+
+exec geth \
+	--datadir="$GETH_DATA_DIR" \
+	--verbosity="$VERBOSITY" \
+	--http \
+	--http.corsdomain="*" \
+	--http.vhosts="*" \
+	--http.addr=0.0.0.0 \
+	--http.port="$RPC_PORT" \
+	--http.api=web3,debug,eth,txpool,net,engine \
+	--ws \
+	--ws.addr=0.0.0.0 \
+	--ws.port="$WS_PORT" \
+	--ws.origins="*" \
+	--ws.api=debug,eth,txpool,net,engine \
+	--syncmode=full \
+	--nodiscover \
+	--maxpeers=1 \
+	--networkid=$CHAIN_ID \
+	--unlock=$BLOCK_SIGNER_ADDRESS \
+	--mine \
+	--miner.etherbase=$BLOCK_SIGNER_ADDRESS \
+	--password="$GETH_DATA_DIR"/password \
+	--allow-insecure-unlock \
+	--authrpc.addr="0.0.0.0" \
+	--authrpc.port="8551" \
+	--authrpc.vhosts="*" \
+	--authrpc.jwtsecret=/config/jwt-secret.txt \
+	--gcmode=archive \
+	--metrics \
+	--metrics.addr=0.0.0.0 \
+	--metrics.port=6060 \
+	"$@"
+

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -293,8 +293,8 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, tx *types.Transaction) error
 		if err != nil {
 			return err
 		}
-		if err := b.eth.seqRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data)); err != nil {
-			return err
+		if err = b.eth.seqRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data)); err != nil {
+			return fmt.Errorf("failed to forward tx to sequencer, please try again")
 		}
 		if b.disableTxPool {
 			return nil

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -49,6 +49,7 @@ import (
 type EthAPIBackend struct {
 	extRPCEnabled       bool
 	allowUnprotectedTxs bool
+	disableTxPool       bool
 	eth                 *Ethereum
 	gpo                 *gasprice.Oracle
 }
@@ -295,10 +296,16 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, tx *types.Transaction) error
 		if err := b.eth.seqRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(data)); err != nil {
 			return err
 		}
+		if b.disableTxPool {
+			return nil
+		}
 		// Retain tx in local tx pool after forwarding, for local RPC usage.
 		if err := b.eth.txPool.AddLocal(tx); err != nil {
 			log.Warn("successfully sent tx to sequencer, but failed to persist in local tx pool", "err", err, "tx", tx.Hash())
 		}
+		return nil
+	}
+	if b.disableTxPool {
 		return nil
 	}
 	return b.eth.txPool.AddLocal(tx)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -199,6 +199,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	)
 	// Override the chain config with provided settings.
 	var overrides core.ChainOverrides
+	if config.OverrideMantleBaseFee != nil {
+		overrides.OverrideMantleBaseFee = config.OverrideMantleBaseFee
+	}
 	if config.OverrideShanghai != nil {
 		overrides.OverrideShanghai = config.OverrideShanghai
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -257,7 +257,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, eth.isLocalBlock)
 	eth.miner.SetExtra(makeExtraData(config.Miner.ExtraData))
 
-	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, eth, nil}
+	eth.APIBackend = &EthAPIBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, config.RollupDisableTxPoolAdmission, eth, nil}
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -365,6 +365,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			NoTxPool:     payloadAttributes.NoTxPool,
 			Transactions: transactions,
 			GasLimit:     payloadAttributes.GasLimit,
+			BaseFee:      payloadAttributes.BaseFee,
 		}
 		id := args.Id()
 		// If we already are busy generating this work, then we do not need

--- a/eth/catalyst/api_test.go
+++ b/eth/catalyst/api_test.go
@@ -109,6 +109,7 @@ func TestEth2AssembleBlock(t *testing.T) {
 	ethservice.TxPool().AddLocal(tx)
 	blockParams := engine.PayloadAttributes{
 		Timestamp: blocks[9].Time() + 5,
+		BaseFee:   big.NewInt(params.InitialBaseFee),
 	}
 	// The miner needs to pick up on the txs in the pool, so a few retries might be
 	// needed.
@@ -145,6 +146,7 @@ func TestEth2AssembleBlockWithAnotherBlocksTxs(t *testing.T) {
 	api.eth.TxPool().AddRemotesSync(blocks[9].Transactions())
 	blockParams := engine.PayloadAttributes{
 		Timestamp: blocks[8].Time() + 5,
+		BaseFee:   big.NewInt(params.InitialBaseFee),
 	}
 	// The miner needs to pick up on the txs in the pool, so a few retries might be
 	// needed.
@@ -184,6 +186,7 @@ func TestEth2PrepareAndGetPayload(t *testing.T) {
 	ethservice.TxPool().AddLocals(blocks[9].Transactions())
 	blockParams := engine.PayloadAttributes{
 		Timestamp: blocks[8].Time() + 5,
+		BaseFee:   big.NewInt(params.InitialBaseFee),
 	}
 	fcState := engine.ForkchoiceStateV1{
 		HeadBlockHash:      blocks[8].Hash(),
@@ -265,6 +268,7 @@ func TestInvalidPayloadTimestamp(t *testing.T) {
 				Timestamp:             test.time,
 				Random:                crypto.Keccak256Hash([]byte{byte(123)}),
 				SuggestedFeeRecipient: parent.Coinbase,
+				BaseFee:               big.NewInt(params.InitialBaseFee),
 			}
 			fcState := engine.ForkchoiceStateV1{
 				HeadBlockHash:      parent.Hash(),
@@ -307,6 +311,7 @@ func TestEth2NewBlock(t *testing.T) {
 
 		execData, err := assembleWithTransactions(api, parent.Hash(), &engine.PayloadAttributes{
 			Timestamp: parent.Time() + 5,
+			BaseFee:   big.NewInt(params.InitialBaseFee),
 		}, 1)
 		if err != nil {
 			t.Fatalf("Failed to create the executable data %v", err)
@@ -349,6 +354,7 @@ func TestEth2NewBlock(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		execData, err := assembleBlock(api, parent.Hash(), &engine.PayloadAttributes{
 			Timestamp: parent.Time() + 6,
+			BaseFee:   big.NewInt(params.InitialBaseFee),
 		})
 		if err != nil {
 			t.Fatalf("Failed to create the executable data %v", err)
@@ -604,6 +610,7 @@ func TestNewPayloadOnInvalidChain(t *testing.T) {
 				Timestamp:             parent.Time + 1,
 				Random:                crypto.Keccak256Hash([]byte{byte(i)}),
 				SuggestedFeeRecipient: parent.Coinbase,
+				BaseFee:               big.NewInt(params.InitialBaseFee),
 			}
 			fcState = engine.ForkchoiceStateV1{
 				HeadBlockHash:      parent.Hash(),
@@ -664,6 +671,7 @@ func assembleBlock(api *ConsensusAPI, parentHash common.Hash, params *engine.Pay
 		FeeRecipient: params.SuggestedFeeRecipient,
 		Random:       params.Random,
 		Withdrawals:  params.Withdrawals,
+		BaseFee:      params.BaseFee,
 	}
 	payload, err := api.eth.Miner().BuildPayload(args)
 	if err != nil {
@@ -738,6 +746,7 @@ func getNewPayload(t *testing.T, api *ConsensusAPI, parent *types.Header, withdr
 		Random:                crypto.Keccak256Hash([]byte{byte(1)}),
 		SuggestedFeeRecipient: parent.Coinbase,
 		Withdrawals:           withdrawals,
+		BaseFee:               big.NewInt(params.InitialBaseFee),
 	}
 
 	payload, err := assembleBlock(api, parent.Hash(), &params)
@@ -907,6 +916,7 @@ func TestNewPayloadOnInvalidTerminalBlock(t *testing.T) {
 		Timestamp:    parent.Time() + 1,
 		Random:       crypto.Keccak256Hash([]byte{byte(1)}),
 		FeeRecipient: parent.Coinbase(),
+		BaseFee:      big.NewInt(params.InitialBaseFee),
 	}
 	payload, err := api.eth.Miner().BuildPayload(args)
 	if err != nil {
@@ -937,6 +947,7 @@ func TestSimultaneousNewBlock(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		execData, err := assembleBlock(api, parent.Hash(), &engine.PayloadAttributes{
 			Timestamp: parent.Time() + 5,
+			BaseFee:   big.NewInt(params.InitialBaseFee),
 		})
 		if err != nil {
 			t.Fatalf("Failed to create the executable data %v", err)
@@ -1029,6 +1040,7 @@ func TestWithdrawals(t *testing.T) {
 	blockParams := engine.PayloadAttributes{
 		Timestamp:   parent.Time + 5,
 		Withdrawals: make([]*types.Withdrawal, 0),
+		BaseFee:     big.NewInt(params.InitialBaseFee),
 	}
 	fcState := engine.ForkchoiceStateV1{
 		HeadBlockHash: parent.Hash(),
@@ -1081,6 +1093,7 @@ func TestWithdrawals(t *testing.T) {
 				Amount:  33,
 			},
 		},
+		BaseFee: big.NewInt(params.InitialBaseFee),
 	}
 	fcState.HeadBlockHash = execData.ExecutionPayload.BlockHash
 	_, err = api.ForkchoiceUpdatedV2(fcState, &blockParams)
@@ -1150,6 +1163,7 @@ func TestNilWithdrawals(t *testing.T) {
 			blockParams: engine.PayloadAttributes{
 				Timestamp:   parent.Time + 2,
 				Withdrawals: nil,
+				BaseFee:     big.NewInt(params.InitialBaseFee),
 			},
 			wantErr: false,
 		},
@@ -1157,6 +1171,7 @@ func TestNilWithdrawals(t *testing.T) {
 			blockParams: engine.PayloadAttributes{
 				Timestamp:   parent.Time + 2,
 				Withdrawals: make([]*types.Withdrawal, 0),
+				BaseFee:     big.NewInt(params.InitialBaseFee),
 			},
 			wantErr: true,
 		},
@@ -1170,6 +1185,7 @@ func TestNilWithdrawals(t *testing.T) {
 						Amount:  32,
 					},
 				},
+				BaseFee: big.NewInt(params.InitialBaseFee),
 			},
 			wantErr: true,
 		},
@@ -1178,6 +1194,7 @@ func TestNilWithdrawals(t *testing.T) {
 			blockParams: engine.PayloadAttributes{
 				Timestamp:   parent.Time + 5,
 				Withdrawals: nil,
+				BaseFee:     big.NewInt(params.InitialBaseFee),
 			},
 			wantErr: true,
 		},
@@ -1185,6 +1202,7 @@ func TestNilWithdrawals(t *testing.T) {
 			blockParams: engine.PayloadAttributes{
 				Timestamp:   parent.Time + 5,
 				Withdrawals: make([]*types.Withdrawal, 0),
+				BaseFee:     big.NewInt(params.InitialBaseFee),
 			},
 			wantErr: false,
 		},
@@ -1198,6 +1216,7 @@ func TestNilWithdrawals(t *testing.T) {
 						Amount:  32,
 					},
 				},
+				BaseFee: big.NewInt(params.InitialBaseFee),
 			},
 			wantErr: false,
 		},

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -206,6 +206,9 @@ type Config struct {
 	// CheckpointOracle is the configuration for checkpoint oracle.
 	CheckpointOracle *params.CheckpointOracleConfig `toml:",omitempty"`
 
+	// OverrideMantleBaseFee (TODO: remove after the fork)
+	OverrideMantleBaseFee *big.Int `toml:",omitempty"`
+
 	// OverrideShanghai (TODO: remove after the fork)
 	OverrideShanghai *uint64 `toml:",omitempty"`
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -87,10 +87,10 @@ var Defaults = Config{
 	FilterLogCacheSize:      32,
 	Miner:                   miner.DefaultConfig,
 	TxPool:                  txpool.DefaultConfig,
-	RPCGasCap:               50000000,
+	RPCGasCap:               core.DefaultMantleBlockGasLimit,
 	RPCEVMTimeout:           5 * time.Second,
 	GPO:                     FullNodeGPO,
-	RPCTxFeeCap:             1, // 1 ether
+	RPCTxFeeCap:             5000, // 5000 mnt
 }
 
 func init() {

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -213,10 +213,11 @@ type Config struct {
 	OverrideOptimismRegolith *uint64 `toml:",omitempty"`
 	OverrideOptimism         *bool
 
-	RollupSequencerHTTP        string
-	RollupHistoricalRPC        string
-	RollupHistoricalRPCTimeout time.Duration
-	RollupDisableTxPoolGossip  bool
+	RollupSequencerHTTP          string
+	RollupHistoricalRPC          string
+	RollupHistoricalRPCTimeout   time.Duration
+	RollupDisableTxPoolGossip    bool
+	RollupDisableTxPoolAdmission bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -979,7 +979,7 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 		config.BlockOverrides.Apply(&vmctx)
 	}
 	// Execute the trace
-	msg, err := args.ToMessage(api.backend.RPCGasCap(), block.BaseFee())
+	msg, err := args.ToMessage(api.backend.RPCGasCap(), block.BaseFee(), core.EthcallMode, args.GasPrice)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/misc"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/filters"
@@ -1069,7 +1070,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 			return nil, err
 		}
 	}
-	result, err := ethapi.DoCall(ctx, b.r.backend, args.Data, *b.numberOrHash, nil, b.r.backend.RPCEVMTimeout(), b.r.backend.RPCGasCap())
+	result, err := ethapi.DoCall(ctx, b.r.backend, args.Data, *b.numberOrHash, nil, b.r.backend.RPCEVMTimeout(), b.r.backend.RPCGasCap(), core.EthcallMode, args.Data.GasPrice)
 	if err != nil {
 		return nil, err
 	}
@@ -1139,7 +1140,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (*CallResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	result, err := ethapi.DoCall(ctx, p.r.backend, args.Data, pendingBlockNr, nil, p.r.backend.RPCEVMTimeout(), p.r.backend.RPCGasCap())
+	result, err := ethapi.DoCall(ctx, p.r.backend, args.Data, pendingBlockNr, nil, p.r.backend.RPCEVMTimeout(), p.r.backend.RPCGasCap(), core.EthcallMode, args.Data.GasPrice)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1232,21 +1232,25 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		if err != nil {
 			return 0, err
 		}
-		if metaTxParams != nil {
-			sponsorAmount, _ := types.CalculateSponsorPercentAmount(metaTxParams, feeCap)
-			sponsorBalance := state.GetBalance(metaTxParams.GasFeeSponsor)
-			if sponsorBalance.Cmp(sponsorAmount) <= 0 {
-				return 0, types.ErrSponsorBalanceNotEnough
-			}
-			balance = new(big.Int).Add(balance, sponsorAmount)
-		}
+
 		available := new(big.Int).Set(balance)
 		if args.Value != nil {
-			if args.Value.ToInt().Cmp(available) >= 0 {
+			if args.Value.ToInt().Cmp(available) > 0 {
 				return 0, core.ErrInsufficientFundsForTransfer
 			}
 			available.Sub(available, args.Value.ToInt())
 		}
+
+		if metaTxParams != nil {
+			sponsorAmount, _ := types.CalculateSponsorPercentAmount(metaTxParams, new(big.Int).Mul(feeCap, new(big.Int).SetUint64(hi)))
+			sponsorBalance := state.GetBalance(metaTxParams.GasFeeSponsor)
+			if sponsorAmount.Cmp(sponsorBalance) < 0 {
+				available.Add(available, sponsorAmount)
+			} else {
+				available.Add(available, sponsorBalance)
+			}
+		}
+
 		allowance := new(big.Int).Div(available, feeCap)
 
 		// If the allowance is larger than maximum uint64, skip checking
@@ -1327,21 +1331,23 @@ func calculateGasWithAllowance(ctx context.Context, b Backend, args TransactionA
 	if err != nil {
 		return 0, err
 	}
+
+	available := new(big.Int).Set(balance)
+	if args.Value != nil {
+		if args.Value.ToInt().Cmp(available) > 0 {
+			return 0, core.ErrInsufficientFundsForTransfer
+		}
+		available.Sub(available, args.Value.ToInt())
+	}
 	if metaTxParams != nil {
 		feeCap := new(big.Int).Mul(gasPriceForEstimate, big.NewInt(0).SetUint64(gasCap))
 		sponsorAmount, _ := types.CalculateSponsorPercentAmount(metaTxParams, feeCap)
 		sponsorBalance := state.GetBalance(metaTxParams.GasFeeSponsor)
-		if sponsorBalance.Cmp(sponsorAmount) <= 0 {
-			return 0, types.ErrSponsorBalanceNotEnough
+		if sponsorAmount.Cmp(sponsorBalance) < 0 {
+			available.Add(available, sponsorAmount)
+		} else {
+			available.Add(available, sponsorBalance)
 		}
-		balance = new(big.Int).Add(balance, sponsorAmount)
-	}
-	available := new(big.Int).Set(balance)
-	if args.Value != nil {
-		if args.Value.ToInt().Cmp(available) >= 0 {
-			return 0, core.ErrInsufficientFundsForTransfer
-		}
-		available.Sub(available, args.Value.ToInt())
 	}
 
 	allowanceGas := new(big.Int).Div(available, gasPriceForEstimate)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1933,7 +1933,9 @@ func (s *TransactionAPI) GetTransactionReceipt(ctx context.Context, hash common.
 		fields["l1GasUsed"] = (*hexutil.Big)(receipt.L1GasUsed)
 		fields["l1Fee"] = (*hexutil.Big)(receipt.L1Fee)
 		fields["l1FeeScalar"] = receipt.FeeScalar.String()
-		fields["tokenRatio"] = (*hexutil.Big)(receipt.TokenRatio)
+		if receipt.TokenRatio != nil {
+			fields["tokenRatio"] = (*hexutil.Big)(receipt.TokenRatio)
+		}
 	}
 	if s.b.ChainConfig().Optimism != nil && tx.IsDepositTx() && receipt.DepositNonce != nil {
 		fields["depositNonce"] = hexutil.Uint64(*receipt.DepositNonce)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1430,6 +1430,7 @@ type RPCTransaction struct {
 	// deposit-tx only
 	SourceHash *common.Hash `json:"sourceHash,omitempty"`
 	Mint       *hexutil.Big `json:"mint,omitempty"`
+	EthValue   *hexutil.Big `json:"ethValue,omitempty"`
 	IsSystemTx *bool        `json:"isSystemTx,omitempty"`
 }
 
@@ -1469,6 +1470,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 			result.IsSystemTx = &isSystemTx
 		}
 		result.Mint = (*hexutil.Big)(tx.Mint())
+		result.EthValue = (*hexutil.Big)(tx.ETHValue())
 		if receipt != nil && receipt.DepositNonce != nil {
 			result.Nonce = hexutil.Uint64(*receipt.DepositNonce)
 		}

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -258,9 +258,28 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 
 	// use suggested gasPrice for estimateGas to calculate gasUsed
 	if runMode == core.GasEstimationMode || runMode == core.GasEstimationWithSkipCheckBalanceMode {
-		gasPrice = gasPriceForEstimate.ToInt()
-		gasFeeCap = gasPriceForEstimate.ToInt()
-		gasTipCap = gasPriceForEstimate.ToInt()
+		// use default gasPrice if user does not set gasPrice or gasPrice is 0
+		if args.GasPrice == nil && gasPrice.Cmp(common.Big0) == 0 {
+			gasPrice = gasPriceForEstimate.ToInt()
+		}
+		// use gasTipCap to set gasFeeCap
+		if args.MaxFeePerGas == nil && args.MaxPriorityFeePerGas != nil {
+			gasFeeCap = args.MaxPriorityFeePerGas.ToInt()
+		}
+		// use gasFeeCap to set gasTipCap
+		if args.MaxPriorityFeePerGas == nil && args.MaxFeePerGas != nil {
+			gasTipCap = args.MaxFeePerGas.ToInt()
+		}
+		// use default gasPrice to set gasFeeCap & gasTipCap if user set gasPrice
+		if args.GasPrice != nil {
+			gasFeeCap = gasPrice
+			gasTipCap = gasPrice
+		}
+		// use default gasPrice to set gasFeeCap & gasTipCap if user does not set any value
+		if args.MaxFeePerGas == nil && args.MaxPriorityFeePerGas == nil && args.GasPrice == nil {
+			gasFeeCap = gasPriceForEstimate.ToInt()
+			gasTipCap = gasPriceForEstimate.ToInt()
+		}
 	}
 
 	value := new(big.Int)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -264,6 +264,11 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 	if args.AccessList != nil {
 		accessList = *args.AccessList
 	}
+	metaTxParams, err := types.DecodeMetaTxParams(data)
+	if err != nil {
+		return nil, err
+	}
+
 	msg := &core.Message{
 		From:              addr,
 		To:                args.To,
@@ -274,6 +279,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int) (*
 		GasTipCap:         gasTipCap,
 		Data:              data,
 		AccessList:        accessList,
+		MetaTxParams:      metaTxParams,
 		SkipAccountChecks: true,
 	}
 	return msg, nil

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -260,6 +260,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 	if runMode == core.GasEstimationMode || runMode == core.GasEstimationWithSkipCheckBalanceMode {
 		gasPrice = gasPriceForEstimate.ToInt()
 		gasFeeCap = gasPriceForEstimate.ToInt()
+		gasTipCap = gasPriceForEstimate.ToInt()
 	}
 
 	value := new(big.Int)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -257,7 +257,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 	}
 
 	// use suggested gasPrice for estimateGas to calculate gasUsed
-	if runMode == core.GasEstimationMode {
+	if runMode == core.GasEstimationMode || runMode == core.GasEstimationWithSkipCheckBalanceMode {
 		gasPrice = gasPriceForEstimate.ToInt()
 		gasFeeCap = gasPriceForEstimate.ToInt()
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -68,7 +68,7 @@ type Config struct {
 
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
-	GasCeil:  30000000,
+	GasCeil:  core.DefaultMantleBlockGasLimit,
 	GasPrice: big.NewInt(params.GWei),
 
 	// The default recommit time is chosen as two seconds since

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -44,6 +44,7 @@ type BuildPayloadArgs struct {
 	NoTxPool     bool                 // Optimism addition: option to disable tx pool contents from being included
 	Transactions []*types.Transaction // Optimism addition: txs forced into the block via engine API
 	GasLimit     *uint64              // Optimism addition: override gas limit of the block to build
+	BaseFee      *big.Int             // Optimism addition: override base fee of the block to build
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.
@@ -173,7 +174,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 	// Build the initial version with no transaction included. It should be fast
 	// enough to run. The empty payload can at least make sure there is something
 	// to deliver for not missing slot.
-	empty, _, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, true, args.Transactions, args.GasLimit)
+	empty, _, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, true, args.Transactions, args.GasLimit, args.BaseFee)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +201,7 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 			select {
 			case <-timer.C:
 				start := time.Now()
-				block, fees, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, false, args.Transactions, args.GasLimit)
+				block, fees, err := w.getSealingBlock(args.Parent, args.Timestamp, args.FeeRecipient, args.Random, args.Withdrawals, false, args.Transactions, args.GasLimit, args.BaseFee)
 				if err == nil {
 					payload.update(block, fees, time.Since(start))
 				}

--- a/miner/payload_building_test.go
+++ b/miner/payload_building_test.go
@@ -17,6 +17,7 @@
 package miner
 
 import (
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -43,6 +44,7 @@ func TestBuildPayload(t *testing.T) {
 		Timestamp:    timestamp,
 		Random:       common.Hash{},
 		FeeRecipient: recipient,
+		BaseFee:      big.NewInt(1e9),
 	}
 	payload, err := w.buildPayload(args)
 	if err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1067,7 +1067,10 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
-		header.BaseFee = genParams.baseFee
+		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent)
+		if w.chainConfig.IsMantleBaseFee(header.Number) {
+			header.BaseFee = genParams.baseFee
+		}
 		if genParams.baseFee == nil {
 			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent)
 			log.Debug("header base fee from eip1559 calculator", "baseFee", header.BaseFee.String())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1068,7 +1068,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent)
-		if w.chainConfig.IsMantleBaseFee(header.Number) {
+		if w.chainConfig.IsMantleBaseFee(header.Time) {
 			header.BaseFee = genParams.baseFee
 		}
 		if genParams.baseFee == nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1021,6 +1021,7 @@ type generateParams struct {
 
 	txs      types.Transactions // Deposit transactions to include at the start of the block
 	gasLimit *uint64            // Optional gas limit override
+	baseFee  *big.Int           // Optional base fee override
 }
 
 // prepareWork constructs the sealing task according to the given parameters,
@@ -1066,7 +1067,13 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
-		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent)
+		header.BaseFee = genParams.baseFee
+		if genParams.baseFee == nil {
+			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent)
+			log.Debug("header base fee from eip1559 calculator", "baseFee", header.BaseFee.String())
+		} else {
+			log.Debug("header base fee from catalyst generation parameters", "baseFee", header.BaseFee.String())
+		}
 		if !w.chainConfig.IsLondon(parent.Number) {
 			parentGasLimit := parent.GasLimit * w.chainConfig.ElasticityMultiplier()
 			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
@@ -1292,7 +1299,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 // getSealingBlock generates the sealing block based on the given parameters.
 // The generation result will be passed back via the given channel no matter
 // the generation itself succeeds or not.
-func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, withdrawals types.Withdrawals, noTxs bool, transactions types.Transactions, gasLimit *uint64) (*types.Block, *big.Int, error) {
+func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase common.Address, random common.Hash, withdrawals types.Withdrawals, noTxs bool, transactions types.Transactions, gasLimit *uint64, baseFee *big.Int) (*types.Block, *big.Int, error) {
 	req := &getWorkReq{
 		params: &generateParams{
 			timestamp:   timestamp,
@@ -1305,6 +1312,7 @@ func (w *worker) getSealingBlock(parent common.Hash, timestamp uint64, coinbase 
 			noTxs:       noTxs,
 			txs:         transactions,
 			gasLimit:    gasLimit,
+			baseFee:     baseFee,
 		},
 		result: make(chan *newPayloadResult, 1),
 	}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -635,7 +635,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 
 	// This API should work even when the automatic sealing is not enabled
 	for _, c := range cases {
-		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, nil, nil)
+		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, nil, nil, nil)
 		if c.expectErr {
 			if err == nil {
 				t.Error("Expect error but get nil")
@@ -651,7 +651,7 @@ func testGetSealingWork(t *testing.T, chainConfig *params.ChainConfig, engine co
 	// This API should work even when the automatic sealing is enabled
 	w.start()
 	for _, c := range cases {
-		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, nil, nil)
+		block, _, err := w.getSealingBlock(c.parent, timestamp, c.coinbase, c.random, nil, false, nil, nil, nil)
 		if c.expectErr {
 			if err == nil {
 				t.Error("Expect error but get nil")

--- a/params/config.go
+++ b/params/config.go
@@ -44,7 +44,9 @@ var (
 	BaseGoerliRegolithTime = uint64(1682614800)
 
 	// Mantle chain_id
+	MantleMainnetChainId = big.NewInt(5000)
 	MantleSepoliaChainId = big.NewInt(5003)
+	MantleLocalChainId   = big.NewInt(17)
 )
 
 // TrustedCheckpoints associates each known checkpoint with the genesis hash of
@@ -451,10 +453,12 @@ type ChainConfig struct {
 	MuirGlacierBlock    *big.Int `json:"muirGlacierBlock,omitempty"`    // Eip-2384 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
-	MantleBaseFeeBlock  *big.Int `json:"mantleBaseFeeBlock,omitempty"`  // Mantle BaseFee switch block (nil = no fork, 0 = already on mantle baseFee)
 	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	GrayGlacierBlock    *big.Int `json:"grayGlacierBlock,omitempty"`    // Eip-5133 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	MergeNetsplitBlock  *big.Int `json:"mergeNetsplitBlock,omitempty"`  // Virtual fork after The Merge to use as a network splitter
+
+	// Mantle upgrade configs
+	BaseFeeTime *uint64 `json:"baseFeeTime,omitempty"` // Mantle BaseFee switch time (nil = no fork, 0 = already on mantle baseFee)
 
 	// Fork scheduling was switched from blocks to timestamps here
 
@@ -668,9 +672,9 @@ func (c *ChainConfig) IsLondon(num *big.Int) bool {
 	return isBlockForked(c.LondonBlock, num)
 }
 
-// IsMantleBaseFee returns whether num is either equal to the Mantle BaseFee fork block or greater.
-func (c *ChainConfig) IsMantleBaseFee(num *big.Int) bool {
-	return isBlockForked(c.MantleBaseFeeBlock, num)
+// IsMantleBaseFee returns whether time is either equal to the BaseFee fork time or greater.
+func (c *ChainConfig) IsMantleBaseFee(time uint64) bool {
+	return isTimestampForked(c.BaseFeeTime, time)
 }
 
 // IsArrowGlacier returns whether num is either equal to the Arrow Glacier (EIP-4345) fork block or greater.
@@ -1065,7 +1069,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsBerlin:         c.IsBerlin(num),
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
-		IsMantleBaseFee:  c.IsMantleBaseFee(num),
+		IsMantleBaseFee:  c.IsMantleBaseFee(timestamp),
 		IsShanghai:       c.IsShanghai(timestamp),
 		isCancun:         c.IsCancun(timestamp),
 		isPrague:         c.IsPrague(timestamp),

--- a/params/config.go
+++ b/params/config.go
@@ -42,6 +42,9 @@ var (
 	BaseGoerliChainId          = big.NewInt(84531)
 	// April 27, 2023 @ 5:00:00 pm UTC
 	BaseGoerliRegolithTime = uint64(1682614800)
+
+	// Mantle chain_id
+	MantleSepoliaChainId = big.NewInt(5003)
 )
 
 // TrustedCheckpoints associates each known checkpoint with the genesis hash of
@@ -448,6 +451,7 @@ type ChainConfig struct {
 	MuirGlacierBlock    *big.Int `json:"muirGlacierBlock,omitempty"`    // Eip-2384 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
+	MantleBaseFeeBlock  *big.Int `json:"mantleBaseFeeBlock,omitempty"`  // Mantle BaseFee switch block (nil = no fork, 0 = already on mantle baseFee)
 	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	GrayGlacierBlock    *big.Int `json:"grayGlacierBlock,omitempty"`    // Eip-5133 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	MergeNetsplitBlock  *big.Int `json:"mergeNetsplitBlock,omitempty"`  // Virtual fork after The Merge to use as a network splitter
@@ -662,6 +666,11 @@ func (c *ChainConfig) IsBerlin(num *big.Int) bool {
 // IsLondon returns whether num is either equal to the London fork block or greater.
 func (c *ChainConfig) IsLondon(num *big.Int) bool {
 	return isBlockForked(c.LondonBlock, num)
+}
+
+// IsMantleBaseFee returns whether num is either equal to the Mantle BaseFee fork block or greater.
+func (c *ChainConfig) IsMantleBaseFee(num *big.Int) bool {
+	return isBlockForked(c.MantleBaseFeeBlock, num)
 }
 
 // IsArrowGlacier returns whether num is either equal to the Arrow Glacier (EIP-4345) fork block or greater.
@@ -1033,6 +1042,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai, isCancun, isPrague                 bool
+	IsMantleBaseFee                                         bool
 	IsOptimismBedrock, IsOptimismRegolith                   bool
 }
 
@@ -1055,6 +1065,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsBerlin:         c.IsBerlin(num),
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
+		IsMantleBaseFee:  c.IsMantleBaseFee(num),
 		IsShanghai:       c.IsShanghai(timestamp),
 		isCancun:         c.IsCancun(timestamp),
 		isPrague:         c.IsPrague(timestamp),

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	maxRequestContentLength = 1024 * 1024 * 5
+	maxRequestContentLength = 1024 * 1024 * 32
 	contentType             = "application/json"
 )
 


### PR DESCRIPTION
Core changes:
- $MNT as the Native token and the gas token
    - Utilize $MNT as the Native Token.
    - Employ $MNT as the Gas Token.
    - Modify the minting method of $ETH on L2.
- Gas fee mechanism
    - Modify the fee collection mechanism, where EstimateGas includes an L1 transaction fee and an L2 transaction fee.
    - Introduce the gasOracle module, which periodically updates the ETH/MNT exchange rate in the GasPriceOracle contract. This is used for fee calculations.
- Meta Transactions
    - Protocol-level support for Meta Transactions, facilitating the ability to delegate transaction fees.
    - Support for fee delegation with varying proportions based on different ratios.