### PR TITLE
[R4R]-[op-geth]feat:use actual gasPrice to estimateGas

### DIFF
--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -258,9 +258,28 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 
 	// use suggested gasPrice for estimateGas to calculate gasUsed
 	if runMode == core.GasEstimationMode || runMode == core.GasEstimationWithSkipCheckBalanceMode {
-		gasPrice = gasPriceForEstimate.ToInt()
-		gasFeeCap = gasPriceForEstimate.ToInt()
-		gasTipCap = gasPriceForEstimate.ToInt()
+		// use default gasPrice if user does not set gasPrice or gasPrice is 0
+		if args.GasPrice == nil && gasPrice.Cmp(common.Big0) == 0 {
+			gasPrice = gasPriceForEstimate.ToInt()
+		}
+		// use gasTipCap to set gasFeeCap
+		if args.MaxFeePerGas == nil && args.MaxPriorityFeePerGas != nil {
+			gasFeeCap = args.MaxPriorityFeePerGas.ToInt()
+		}
+		// use gasFeeCap to set gasTipCap
+		if args.MaxPriorityFeePerGas == nil && args.MaxFeePerGas != nil {
+			gasTipCap = args.MaxFeePerGas.ToInt()
+		}
+		// use default gasPrice to set gasFeeCap & gasTipCap if user set gasPrice
+		if args.GasPrice != nil {
+			gasFeeCap = gasPrice
+			gasTipCap = gasPrice
+		}
+		// use default gasPrice to set gasFeeCap & gasTipCap if user does not set any value
+		if args.MaxFeePerGas == nil && args.MaxPriorityFeePerGas == nil && args.GasPrice == nil {
+			gasFeeCap = gasPriceForEstimate.ToInt()
+			gasTipCap = gasPriceForEstimate.ToInt()
+		}
 	}
 
 	value := new(big.Int)


### PR DESCRIPTION
Core changes:
- use actual gasPrice to `estimateGas`, has 8 cases:
  - 1 gasPrice is nil; GasTipCap is nil; GasFeeCap is nil
    - use default gasPrice
  - 2 gasPrice is nil; GasTipCap not nil; GasFeeCap is nil
    - use default gasPrice
  - 3 gasPrice is nil; GasTipCap is nil; GasFeeCap not nil
    - use actual gasPrice
  - 4 gasPrice is nil; GasTipCap not nil; GasFeeCap not nil
    - use actual gasPrice
  - 5 gasPrice not nil; GasTipCap is nil; GasFeeCap is nil
    - use actual gasPrice
  - 6 gasPrice not nil; GasTipCap not nil; GasFeeCap is nil
    - wrong arguments
  - 7 gasPrice not nil; GasTipCap is nil; GasFeeCap not nil
    - wrong arguments
  - 8 gasPrice not nil; GasTipCap not nil; GasFeeCap not nil
    - wrong arguments