### PR TITLE
[R4R]-[baseFee]feat: use block time to determine baseFee upgrade

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -54,7 +54,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		return new(big.Int).SetUint64(params.InitialBaseFee)
 	}
 
-	if config.IsMantleBaseFee(parent.Number) {
+	if config.IsMantleBaseFee(parent.Time) {
 		return new(big.Int).Set(parent.BaseFee)
 	}
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -307,7 +307,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				config.RegolithTime = &params.BaseGoerliRegolithTime
 			}
 
-			mantleUpgradeChainConfig := getUpgradeConfigForMantle(params.MantleSepoliaChainId)
+			mantleUpgradeChainConfig := GetUpgradeConfigForMantle(params.MantleSepoliaChainId)
 			if mantleUpgradeChainConfig != nil {
 				config.BaseFeeTime = mantleUpgradeChainConfig.BaseFeeTime
 			}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -309,7 +309,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 
 			mantleUpgradeChainConfig := getUpgradeConfigForMantle(params.MantleSepoliaChainId)
 			if mantleUpgradeChainConfig != nil {
-				config.MantleBaseFeeBlock = mantleUpgradeChainConfig.MantleBaseFeeForSepolia
+				config.BaseFeeTime = mantleUpgradeChainConfig.BaseFeeTime
 			}
 
 			if overrides != nil && overrides.OverrideShanghai != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -307,7 +307,7 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 				config.RegolithTime = &params.BaseGoerliRegolithTime
 			}
 
-			mantleUpgradeChainConfig := GetUpgradeConfigForMantle(params.MantleSepoliaChainId)
+			mantleUpgradeChainConfig := GetUpgradeConfigForMantle(config.ChainID)
 			if mantleUpgradeChainConfig != nil {
 				config.BaseFeeTime = mantleUpgradeChainConfig.BaseFeeTime
 			}

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -24,10 +24,13 @@ type MantleUpgradeChainConfig struct {
 }
 
 func GetUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
-	switch chainID {
-	case params.MantleMainnetChainId:
+	if chainID == nil {
+		return nil
+	}
+	switch chainID.Int64() {
+	case params.MantleMainnetChainId.Int64():
 		return &MantleMainnetUpgradeConfig
-	case params.MantleSepoliaChainId:
+	case params.MantleSepoliaChainId.Int64():
 		return &MantleSepoliaUpgradeConfig
 	default:
 		return nil

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -7,6 +7,11 @@ import (
 )
 
 var (
+	MantleMainnetUpgradeConfig = MantleUpgradeChainConfig{
+		ChainID:     params.MantleMainnetChainId,
+		BaseFeeTime: u64Ptr(0),
+	}
+
 	MantleSepoliaUpgradeConfig = MantleUpgradeChainConfig{
 		ChainID:     params.MantleSepoliaChainId,
 		BaseFeeTime: u64Ptr(1_703_759_533),
@@ -18,8 +23,10 @@ type MantleUpgradeChainConfig struct {
 	BaseFeeTime *uint64  `json:"BaseFeeTime"` // Mantle BaseFee switch time (nil = no fork, 0 = already on mantle baseFee)
 }
 
-func getUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
+func GetUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
 	switch chainID {
+	case params.MantleMainnetChainId:
+		return &MantleMainnetUpgradeConfig
 	case params.MantleSepoliaChainId:
 		return &MantleSepoliaUpgradeConfig
 	default:

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -17,7 +17,7 @@ var (
 		BaseFeeTime: u64Ptr(1_703_759_533),
 	}
 	MantleLocalUpgradeConfig = MantleUpgradeChainConfig{
-		ChainID:     params.MantleSepoliaChainId,
+		ChainID:     params.MantleLocalChainId,
 		BaseFeeTime: u64Ptr(0),
 	}
 )

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -16,6 +16,10 @@ var (
 		ChainID:     params.MantleSepoliaChainId,
 		BaseFeeTime: u64Ptr(1_703_759_533),
 	}
+	MantleLocalUpgradeConfig = MantleUpgradeChainConfig{
+		ChainID:     params.MantleSepoliaChainId,
+		BaseFeeTime: u64Ptr(0),
+	}
 )
 
 type MantleUpgradeChainConfig struct {
@@ -32,6 +36,8 @@ func GetUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
 		return &MantleMainnetUpgradeConfig
 	case params.MantleSepoliaChainId.Int64():
 		return &MantleSepoliaUpgradeConfig
+	case params.MantleLocalChainId.Int64():
+		return &MantleLocalUpgradeConfig
 	default:
 		return nil
 	}

--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -8,14 +8,14 @@ import (
 
 var (
 	MantleSepoliaUpgradeConfig = MantleUpgradeChainConfig{
-		ChainID:                 params.MantleSepoliaChainId,
-		MantleBaseFeeForSepolia: big.NewInt(473_611),
+		ChainID:     params.MantleSepoliaChainId,
+		BaseFeeTime: u64Ptr(1_703_759_533),
 	}
 )
 
 type MantleUpgradeChainConfig struct {
-	ChainID                 *big.Int `json:"chainId"`                 // chainId identifies the current chain and is used for replay protection
-	MantleBaseFeeForSepolia *big.Int `json:"MantleBaseFeeForSepolia"` // Mantle BaseFee switch block (nil = no fork, 0 = already on mantle baseFee)
+	ChainID     *big.Int `json:"chainId"`     // chainId identifies the current chain and is used for replay protection
+	BaseFeeTime *uint64  `json:"BaseFeeTime"` // Mantle BaseFee switch time (nil = no fork, 0 = already on mantle baseFee)
 }
 
 func getUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
@@ -25,4 +25,8 @@ func getUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
 	default:
 		return nil
 	}
+}
+
+func u64Ptr(v uint64) *uint64 {
+	return &v
 }

--- a/core/mantle_upgrade_test.go
+++ b/core/mantle_upgrade_test.go
@@ -3,21 +3,21 @@ package core
 import (
 	"math/big"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/params"
 )
 
 var (
-	NonExistChainID = big.NewInt(-1)
+	MantleMainnetChainId = big.NewInt(5000)
+	MantleSepoliaChainId = big.NewInt(5003)
+	NonExistChainID      = big.NewInt(-1)
 )
 
 func TestGetUpgradeConfigForMantle(t *testing.T) {
-	mainnetUpgradeConfig := GetUpgradeConfigForMantle(params.MantleMainnetChainId)
+	mainnetUpgradeConfig := GetUpgradeConfigForMantle(MantleMainnetChainId)
 	if *mainnetUpgradeConfig.BaseFeeTime != *MantleMainnetUpgradeConfig.BaseFeeTime {
 		t.Errorf("wrong baseFeeTime: got %v, want %v", *mainnetUpgradeConfig.BaseFeeTime, *MantleMainnetUpgradeConfig.BaseFeeTime)
 	}
 
-	sepoliaUpgradeConfig := GetUpgradeConfigForMantle(params.MantleSepoliaChainId)
+	sepoliaUpgradeConfig := GetUpgradeConfigForMantle(MantleSepoliaChainId)
 	if *sepoliaUpgradeConfig.BaseFeeTime != *MantleSepoliaUpgradeConfig.BaseFeeTime {
 		t.Errorf("wrong baseFeeTime: got %v, want %v", *sepoliaUpgradeConfig.BaseFeeTime, *MantleSepoliaUpgradeConfig.BaseFeeTime)
 	}

--- a/core/mantle_upgrade_test.go
+++ b/core/mantle_upgrade_test.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/params"
+)
+
+var (
+	NonExistChainID = big.NewInt(-1)
+)
+
+func TestGetUpgradeConfigForMantle(t *testing.T) {
+	mainnetUpgradeConfig := GetUpgradeConfigForMantle(params.MantleMainnetChainId)
+	if *mainnetUpgradeConfig.BaseFeeTime != *MantleMainnetUpgradeConfig.BaseFeeTime {
+		t.Errorf("wrong baseFeeTime: got %v, want %v", *mainnetUpgradeConfig.BaseFeeTime, *MantleMainnetUpgradeConfig.BaseFeeTime)
+	}
+
+	sepoliaUpgradeConfig := GetUpgradeConfigForMantle(params.MantleSepoliaChainId)
+	if *sepoliaUpgradeConfig.BaseFeeTime != *MantleSepoliaUpgradeConfig.BaseFeeTime {
+		t.Errorf("wrong baseFeeTime: got %v, want %v", *sepoliaUpgradeConfig.BaseFeeTime, *MantleSepoliaUpgradeConfig.BaseFeeTime)
+	}
+
+	upgradeConfig := GetUpgradeConfigForMantle(NonExistChainID)
+	if upgradeConfig != nil {
+		t.Errorf("upgradeConfig should be nil, upgradeConfig: got %v, want %v", upgradeConfig, nil)
+	}
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1068,7 +1068,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent)
-		if w.chainConfig.IsMantleBaseFee(header.Number) {
+		if w.chainConfig.IsMantleBaseFee(header.Time) {
 			header.BaseFee = genParams.baseFee
 		}
 		if genParams.baseFee == nil {

--- a/params/config.go
+++ b/params/config.go
@@ -44,6 +44,7 @@ var (
 	BaseGoerliRegolithTime = uint64(1682614800)
 
 	// Mantle chain_id
+	MantleMainnetChainId = big.NewInt(5000)
 	MantleSepoliaChainId = big.NewInt(5003)
 )
 

--- a/params/config.go
+++ b/params/config.go
@@ -451,10 +451,12 @@ type ChainConfig struct {
 	MuirGlacierBlock    *big.Int `json:"muirGlacierBlock,omitempty"`    // Eip-2384 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
-	MantleBaseFeeBlock  *big.Int `json:"mantleBaseFeeBlock,omitempty"`  // Mantle BaseFee switch block (nil = no fork, 0 = already on mantle baseFee)
 	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	GrayGlacierBlock    *big.Int `json:"grayGlacierBlock,omitempty"`    // Eip-5133 (bomb delay) switch block (nil = no fork, 0 = already activated)
 	MergeNetsplitBlock  *big.Int `json:"mergeNetsplitBlock,omitempty"`  // Virtual fork after The Merge to use as a network splitter
+
+	// Mantle upgrade configs
+	BaseFeeTime *uint64 `json:"baseFeeTime,omitempty"` // Mantle BaseFee switch time (nil = no fork, 0 = already on mantle baseFee)
 
 	// Fork scheduling was switched from blocks to timestamps here
 
@@ -668,9 +670,9 @@ func (c *ChainConfig) IsLondon(num *big.Int) bool {
 	return isBlockForked(c.LondonBlock, num)
 }
 
-// IsMantleBaseFee returns whether num is either equal to the Mantle BaseFee fork block or greater.
-func (c *ChainConfig) IsMantleBaseFee(num *big.Int) bool {
-	return isBlockForked(c.MantleBaseFeeBlock, num)
+// IsMantleBaseFee returns whether time is either equal to the BaseFee fork time or greater.
+func (c *ChainConfig) IsMantleBaseFee(time uint64) bool {
+	return isTimestampForked(c.BaseFeeTime, time)
 }
 
 // IsArrowGlacier returns whether num is either equal to the Arrow Glacier (EIP-4345) fork block or greater.
@@ -1065,7 +1067,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsBerlin:         c.IsBerlin(num),
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
-		IsMantleBaseFee:  c.IsMantleBaseFee(num),
+		IsMantleBaseFee:  c.IsMantleBaseFee(timestamp),
 		IsShanghai:       c.IsShanghai(timestamp),
 		isCancun:         c.IsCancun(timestamp),
 		isPrague:         c.IsPrague(timestamp),

--- a/params/config.go
+++ b/params/config.go
@@ -46,6 +46,7 @@ var (
 	// Mantle chain_id
 	MantleMainnetChainId = big.NewInt(5000)
 	MantleSepoliaChainId = big.NewInt(5003)
+	MantleLocalChainId   = big.NewInt(17)
 )
 
 // TrustedCheckpoints associates each known checkpoint with the genesis hash of


### PR DESCRIPTION
Core changes:
- use `block timestamp` as `BaseFee` upgrade flag