### PR TITLE
Leo/set default basefee upgrade config

### DIFF
--- a/core/mantle_upgrade.go
+++ b/core/mantle_upgrade.go
@@ -20,6 +20,9 @@ var (
 		ChainID:     params.MantleLocalChainId,
 		BaseFeeTime: u64Ptr(0),
 	}
+	MantleDefaultUpgradeConfig = MantleUpgradeChainConfig{
+		BaseFeeTime: u64Ptr(0),
+	}
 )
 
 type MantleUpgradeChainConfig struct {
@@ -39,7 +42,7 @@ func GetUpgradeConfigForMantle(chainID *big.Int) *MantleUpgradeChainConfig {
 	case params.MantleLocalChainId.Int64():
 		return &MantleLocalUpgradeConfig
 	default:
-		return nil
+		return &MantleDefaultUpgradeConfig
 	}
 }
 

--- a/core/mantle_upgrade_test.go
+++ b/core/mantle_upgrade_test.go
@@ -29,6 +29,6 @@ func TestGetUpgradeConfigForMantle(t *testing.T) {
 
 	defaultUpgradeConfig := GetUpgradeConfigForMantle(OtherChainID)
 	if *defaultUpgradeConfig.BaseFeeTime != *MantleDefaultUpgradeConfig.BaseFeeTime {
-		t.Errorf("upgradeConfig should be nil, upgradeConfig: got %v, want %v", upgradeConfig, nil)
+		t.Errorf("wrong baseFeeTime: got %v, want %v", *defaultUpgradeConfig.BaseFeeTime, *MantleDefaultUpgradeConfig.BaseFeeTime)
 	}
 }

--- a/core/mantle_upgrade_test.go
+++ b/core/mantle_upgrade_test.go
@@ -8,7 +8,7 @@ import (
 var (
 	MantleMainnetChainId = big.NewInt(5000)
 	MantleSepoliaChainId = big.NewInt(5003)
-	NonExistChainID      = big.NewInt(-1)
+	OtherChainID         = big.NewInt(1_000_000)
 )
 
 func TestGetUpgradeConfigForMantle(t *testing.T) {
@@ -22,8 +22,13 @@ func TestGetUpgradeConfigForMantle(t *testing.T) {
 		t.Errorf("wrong baseFeeTime: got %v, want %v", *sepoliaUpgradeConfig.BaseFeeTime, *MantleSepoliaUpgradeConfig.BaseFeeTime)
 	}
 
-	upgradeConfig := GetUpgradeConfigForMantle(NonExistChainID)
+	upgradeConfig := GetUpgradeConfigForMantle(nil)
 	if upgradeConfig != nil {
+		t.Errorf("upgradeConfig should be nil, upgradeConfig: got %v, want %v", upgradeConfig, nil)
+	}
+
+	defaultUpgradeConfig := GetUpgradeConfigForMantle(OtherChainID)
+	if *defaultUpgradeConfig.BaseFeeTime != *MantleDefaultUpgradeConfig.BaseFeeTime {
 		t.Errorf("upgradeConfig should be nil, upgradeConfig: got %v, want %v", upgradeConfig, nil)
 	}
 }


### PR DESCRIPTION
Core change:
- set default baseFee upgrade config for all other chain_ids except `mainnet`\`testnet`\`localnet`