### PR TITLE
R4R: fix metatx estimateGas 

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1235,7 +1235,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 
 		available := new(big.Int).Set(balance)
 		if args.Value != nil {
-			if args.Value.ToInt().Cmp(available) >= 0 {
+			if args.Value.ToInt().Cmp(available) > 0 {
 				return 0, core.ErrInsufficientFundsForTransfer
 			}
 			available.Sub(available, args.Value.ToInt())
@@ -1334,7 +1334,7 @@ func calculateGasWithAllowance(ctx context.Context, b Backend, args TransactionA
 
 	available := new(big.Int).Set(balance)
 	if args.Value != nil {
-		if args.Value.ToInt().Cmp(available) >= 0 {
+		if args.Value.ToInt().Cmp(available) > 0 {
 			return 0, core.ErrInsufficientFundsForTransfer
 		}
 		available.Sub(available, args.Value.ToInt())

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1233,7 +1233,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 			return 0, err
 		}
 		if metaTxParams != nil {
-			sponsorAmount, _ := types.CalculateSponsorPercentAmount(metaTxParams, feeCap)
+			sponsorAmount, _ := types.CalculateSponsorPercentAmount(metaTxParams, new(big.Int).Mul(feeCap, new(big.Int).SetUint64(b.CurrentHeader().GasLimit)))
 			sponsorBalance := state.GetBalance(metaTxParams.GasFeeSponsor)
 			if sponsorBalance.Cmp(sponsorAmount) <= 0 {
 				return 0, types.ErrSponsorBalanceNotEnough
@@ -1329,7 +1329,7 @@ func calculateGasWithAllowance(ctx context.Context, b Backend, args TransactionA
 	}
 	if metaTxParams != nil {
 		feeCap := new(big.Int).Mul(gasPriceForEstimate, big.NewInt(0).SetUint64(gasCap))
-		sponsorAmount, _ := types.CalculateSponsorPercentAmount(metaTxParams, feeCap)
+		sponsorAmount, _ := types.CalculateSponsorPercentAmount(metaTxParams, new(big.Int).Mul(feeCap, new(big.Int).SetUint64(b.CurrentHeader().GasLimit)))
 		sponsorBalance := state.GetBalance(metaTxParams.GasFeeSponsor)
 		if sponsorBalance.Cmp(sponsorAmount) <= 0 {
 			return 0, types.ErrSponsorBalanceNotEnough


### PR DESCRIPTION
 if metatx not nil, sponsorAmount is set by gasCap(price), but should be similar to gasPrice * gasUsed. this causes estimateGas failed if gasUsed larger than 1.(100percent and 0 fromBalance)
e.g.: 100% sponsor, and msg.sender has no MNT. sponsorAmount will be set as feeCap. Balance in total is 0 + feeCap, and will also set to "avaliable". Then allowance is set by avaliable div feeCap, so allowance will be 1. If only the gasUsed larger than 1, error msg "gas required exceeds allowance (1)" will be returned.