### PR TITLE
R4R: feature/ivan:Set suggest tip cap to zero

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -358,7 +358,7 @@ func (b *EthAPIBackend) SyncProgress() ethereum.SyncProgress {
 }
 
 func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	return b.gpo.SuggestTipCap(ctx)
+	return big.NewInt(0), nil
 }
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -269,7 +269,7 @@ func (b *LesApiBackend) ProtocolVersion() int {
 }
 
 func (b *LesApiBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	return b.gpo.SuggestTipCap(ctx)
+	return big.NewInt(0), nil
 }
 
 func (b *LesApiBackend) FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {


### PR DESCRIPTION
In order to prevent normal users' transaction fees from being affected by network priority fees, and to keep the overall network transaction fee as low as possible, basefee is consistent, so cap is set to 0