### PR TITLE
[R4R]-[fee]fix: fix estimateGas; discard invalid tx

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -80,7 +80,7 @@ var (
 
 	// ErrInsufficientGasForL1Cost is returned if the transaction is specified to use less gas
 	// than required for l1Cost.
-	ErrInsufficientGasForL1Cost = errors.New("insufficient gas for l1Cost")
+	ErrInsufficientGasForL1Cost = errors.New("insufficient gas for l1Cost. Please use estimateGas to get gasLimit")
 
 	// ErrTxTypeNotSupported is returned if a transaction is not supported in the
 	// current network configuration.
@@ -101,6 +101,10 @@ var (
 	// ErrFeeCapTooLow is returned if the transaction fee cap is less than the
 	// base fee of the block.
 	ErrFeeCapTooLow = errors.New("max fee per gas less than block base fee")
+
+	// ErrGasPriceTooLow is returned if the transaction gasPrice is less than the
+	// base fee of the block for legacy tx
+	ErrGasPriceTooLow = errors.New("legacy tx's gasPrice less than block base fee")
 
 	// ErrSenderNoEOA is returned if the sender of a transaction is a contract.
 	ErrSenderNoEOA = errors.New("sender not an eoa")

--- a/core/error.go
+++ b/core/error.go
@@ -78,6 +78,10 @@ var (
 	// than required to start the invocation.
 	ErrIntrinsicGas = errors.New("intrinsic gas too low")
 
+	// ErrInsufficientGasForL1Cost is returned if the transaction is specified to use less gas
+	// than required for l1Cost.
+	ErrInsufficientGasForL1Cost = errors.New("insufficient gas for l1Cost")
+
 	// ErrTxTypeNotSupported is returned if a transaction is not supported in the
 	// current network configuration.
 	ErrTxTypeNotSupported = types.ErrTxTypeNotSupported

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -536,10 +536,10 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	if !st.msg.IsDepositTx && !st.msg.IsSystemTx {
 		if st.msg.GasPrice.Cmp(common.Big0) > 0 && l1Cost != nil {
 			l1Gas = new(big.Int).Div(l1Cost, st.msg.GasPrice).Uint64()
-			if st.msg.GasLimit < l1Gas {
-				log.Info("innerTransitionDb-1", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
-				return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
-			}
+			//if st.msg.GasLimit < l1Gas {
+			//	log.Info("innerTransitionDb-1", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
+			//	return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
+			//}
 		}
 		if st.gasRemaining < l1Gas {
 			log.Info("innerTransitionDb-2", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -537,11 +537,13 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		if st.msg.GasPrice.Cmp(common.Big0) > 0 && l1Cost != nil {
 			l1Gas = new(big.Int).Div(l1Cost, st.msg.GasPrice).Uint64()
 			if st.msg.GasLimit < l1Gas {
-				return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gasRemaining, l1Gas)
+				log.Info("innerTransitionDb-1", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
+				return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientFundsForTransfer, st.gasRemaining, l1Gas)
 			}
 		}
 		if st.gasRemaining < l1Gas {
-			return nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gasRemaining, l1Gas)
+			log.Info("innerTransitionDb-2", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
+			return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientFundsForTransfer, st.gasRemaining, l1Gas)
 		}
 		st.gasRemaining -= l1Gas
 		if tokenRatio > 0 {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -523,6 +523,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Info("innerTransitionDb", "tx.Gas()", st.gasRemaining, "tokenRatio", tokenRatio, "gas", gas)
 	if !st.msg.IsDepositTx && !st.msg.IsSystemTx {
 		gas = gas * tokenRatio
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -524,7 +524,6 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		return nil, err
 	}
 
-	log.Info("innerTransitionDb", "gas", gas, "tokenRatio", tokenRatio)
 	if !st.msg.IsDepositTx && !st.msg.IsSystemTx {
 		gas = gas * tokenRatio
 	}
@@ -538,7 +537,6 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		if st.msg.GasPrice.Cmp(common.Big0) > 0 && l1Cost != nil {
 			l1Gas = new(big.Int).Div(l1Cost, st.msg.GasPrice).Uint64()
 		}
-		log.Info("innerTransitionDb", "l1Cost", l1Cost.String(), "st.msg.GasPrice", st.msg.GasPrice, "st.gasRemaining", st.gasRemaining, "tokenRatio", tokenRatio)
 		if st.gasRemaining < l1Gas {
 			return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -523,6 +523,8 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	log.Info("innerTransitionDb", "gas", gas, "tokenRatio", tokenRatio)
 	if !st.msg.IsDepositTx && !st.msg.IsSystemTx {
 		gas = gas * tokenRatio
 	}
@@ -536,6 +538,7 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 		if st.msg.GasPrice.Cmp(common.Big0) > 0 && l1Cost != nil {
 			l1Gas = new(big.Int).Div(l1Cost, st.msg.GasPrice).Uint64()
 		}
+		log.Info("innerTransitionDb", "l1Cost", l1Cost.String(), "st.msg.GasPrice", st.msg.GasPrice, "st.gasRemaining", st.gasRemaining, "tokenRatio", tokenRatio)
 		if st.gasRemaining < l1Gas {
 			return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
 		}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -523,7 +523,6 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info("innerTransitionDb", "tx.Gas()", st.gasRemaining, "tokenRatio", tokenRatio, "gas", gas)
 	if !st.msg.IsDepositTx && !st.msg.IsSystemTx {
 		gas = gas * tokenRatio
 	}
@@ -536,13 +535,8 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 	if !st.msg.IsDepositTx && !st.msg.IsSystemTx {
 		if st.msg.GasPrice.Cmp(common.Big0) > 0 && l1Cost != nil {
 			l1Gas = new(big.Int).Div(l1Cost, st.msg.GasPrice).Uint64()
-			//if st.msg.GasLimit < l1Gas {
-			//	log.Info("innerTransitionDb-1", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
-			//	return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
-			//}
 		}
 		if st.gasRemaining < l1Gas {
-			log.Info("innerTransitionDb-2", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
 			return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
 		}
 		st.gasRemaining -= l1Gas

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -538,12 +538,12 @@ func (st *StateTransition) innerTransitionDb() (*ExecutionResult, error) {
 			l1Gas = new(big.Int).Div(l1Cost, st.msg.GasPrice).Uint64()
 			if st.msg.GasLimit < l1Gas {
 				log.Info("innerTransitionDb-1", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
-				return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientFundsForTransfer, st.gasRemaining, l1Gas)
+				return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
 			}
 		}
 		if st.gasRemaining < l1Gas {
 			log.Info("innerTransitionDb-2", "st.gasRemaining", st.gasRemaining, "l1Gas", l1Gas)
-			return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientFundsForTransfer, st.gasRemaining, l1Gas)
+			return nil, fmt.Errorf("%w: have %d, want %d", ErrInsufficientGasForL1Cost, st.gasRemaining, l1Gas)
 		}
 		st.gasRemaining -= l1Gas
 		if tokenRatio > 0 {

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -760,9 +760,6 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	tokenRatio := pool.currentState.GetState(types.GasOracleAddr, types.TokenRatioSlot).Big().Uint64()
 
-	log.Info("validateTx", "tx.Gas()", tx.Gas(), "tokenRatio", tokenRatio, "intrGas", intrGas)
-	log.Info("validateTx", "tx", *tx, "txhash", tx.Hash().String())
-
 	if tx.Gas() < intrGas*tokenRatio {
 		return core.ErrIntrinsicGas
 	}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core"
@@ -788,14 +787,14 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		}
 	}
 
-	if tx.Type() == types.DynamicFeeTxType {
-		// dynamicBaseFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx
-		effectiveGas := cmath.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
-		dynamicFeeTxL1Cost := new(big.Int).Mul(effectiveGas, gasRemaining)
-		if l1Cost != nil && dynamicFeeTxL1Cost.Cmp(l1Cost) <= 0 {
-			return core.ErrInsufficientGasForL1Cost
-		}
-	}
+	//if tx.Type() == types.DynamicFeeTxType {
+	//	// dynamicBaseFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx
+	//	effectiveGas := cmath.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
+	//	dynamicFeeTxL1Cost := new(big.Int).Mul(effectiveGas, gasRemaining)
+	//	if l1Cost != nil && dynamicFeeTxL1Cost.Cmp(l1Cost) <= 0 {
+	//		return core.ErrInsufficientGasForL1Cost
+	//	}
+	//}
 
 	return nil
 }

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -759,6 +759,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	tokenRatio := pool.currentState.GetState(types.GasOracleAddr, types.TokenRatioSlot).Big().Uint64()
 
+	log.Info("validateTx", "tx.Gas()", tx.Gas(), "tokenRatio", tokenRatio, "intrGas", intrGas)
+	log.Info("validateTx", "tx", *tx, "txhash", tx.Hash().String())
+
 	if tx.Gas() < intrGas*tokenRatio {
 		return core.ErrIntrinsicGas
 	}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -775,11 +775,20 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	log.Info("validateTx", "tx.GasPrice()", tx.GasPrice(), "tx.GasTipCap()", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap(), "gasRemaining", gasRemaining)
 
 	// legacyTxL1Cost gas used to cover L1 Cost for legacy tx
-	legacyTxL1Cost := new(big.Int).Mul(new(big.Int).Add(tx.GasPrice(), tx.GasTipCap()), gasRemaining)
+	legacyTxL1Cost := new(big.Int).Mul(tx.GasPrice(), gasRemaining)
 	if l1Cost != nil && legacyTxL1Cost.Cmp(l1Cost) <= 0 {
 		return core.ErrInsufficientGasForL1Cost
 	}
-	// DynamicFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx
+
+	baseFee := pool.chain.CurrentBlock().BaseFee
+	log.Info("validateTx", "baseFee", baseFee)
+	// dynamicBaseFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx when baseFee + tipCap < feeCap
+	dynamicBaseFeeTxL1Cost := new(big.Int).Mul(new(big.Int).Add(baseFee, tx.GasTipCap()), gasRemaining)
+	if l1Cost != nil && dynamicBaseFeeTxL1Cost.Cmp(l1Cost) <= 0 {
+		return core.ErrInsufficientGasForL1Cost
+	}
+
+	// dynamicFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx when feeCap < baseFee + tipCap
 	dynamicFeeTxL1Cost := new(big.Int).Mul(tx.GasFeeCap(), gasRemaining)
 	if l1Cost != nil && dynamicFeeTxL1Cost.Cmp(l1Cost) <= 0 {
 		return core.ErrInsufficientGasForL1Cost

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -760,11 +760,18 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	tokenRatio := pool.currentState.GetState(types.GasOracleAddr, types.TokenRatioSlot).Big().Uint64()
 
+	log.Info("validateTx", "tx.Gas()", tx.Gas(), "tokenRatio", tokenRatio, "intrGas", intrGas)
+	if l1Cost != nil {
+		log.Info("validateTx", "l1Cost", l1Cost.String())
+	}
+
 	if tx.Gas() < intrGas*tokenRatio {
 		return core.ErrIntrinsicGas
 	}
 
 	gasRemaining := big.NewInt(int64(tx.Gas() - intrGas*tokenRatio))
+	log.Info("validateTx", "tx.GasPrice()", tx.GasPrice(), "tx.GasTipCap()", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap(), "gasRemaining", gasRemaining)
+
 	// legacyTxL1Cost gas used to cover L1 Cost for legacy tx
 	legacyTxL1Cost := new(big.Int).Mul(new(big.Int).Add(tx.GasPrice(), tx.GasTipCap()), gasRemaining)
 	if l1Cost != nil && legacyTxL1Cost.Cmp(l1Cost) <= 0 {

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -763,6 +763,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	log.Info("validateTx", "tx.Gas()", tx.Gas(), "tokenRatio", tokenRatio, "intrGas", intrGas)
 	if l1Cost != nil {
 		log.Info("validateTx", "l1Cost", l1Cost.String())
+	} else {
+		log.Info("validateTx no l1Cost")
 	}
 
 	if tx.Gas() < intrGas*tokenRatio {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1313,7 +1313,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 
 		result, err := DoCall(ctx, b, args, blockNrOrHash, nil, 0, gasCap, runMode, (*hexutil.Big)(gasPriceForEstimateGas))
 		if err != nil {
-			if errors.Is(err, core.ErrIntrinsicGas) {
+			if errors.Is(err, core.ErrIntrinsicGas) || errors.Is(err, core.ErrInsufficientGasForL1Cost) {
 				return true, nil, nil // Special case, raise gas limit
 			}
 			return true, nil, err // Bail out

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1247,6 +1247,10 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		feeCap = gasPriceForEstimateGas
 	}
 
+	if feeCap.Cmp(gasPriceForEstimateGas) < 0 {
+		feeCap = gasPriceForEstimateGas
+	}
+
 	runMode := core.GasEstimationMode
 	if args.GasPrice == nil && args.MaxFeePerGas == nil && args.MaxPriorityFeePerGas == nil {
 		runMode = core.GasEstimationWithSkipCheckBalanceMode

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -280,6 +280,13 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 			gasFeeCap = gasPriceForEstimate.ToInt()
 			gasTipCap = gasPriceForEstimate.ToInt()
 		}
+
+		if gasPrice.Cmp(gasPriceForEstimate.ToInt()) < 0 {
+			gasPrice = gasPriceForEstimate.ToInt()
+		}
+		if gasFeeCap.Cmp(gasPriceForEstimate.ToInt()) < 0 {
+			gasFeeCap = gasPriceForEstimate.ToInt()
+		}
 	}
 
 	value := new(big.Int)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -987,7 +987,7 @@ func (w *worker) commitTransactions(env *environment, txs *types.TransactionsByP
 			// Strange error, discard the transaction and get the next in line (note, the
 			// nonce-too-high clause will prevent us from executing in vain).
 			log.Debug("Transaction failed, account skipped", "hash", tx.Hash(), "err", err)
-			txs.Shift()
+			txs.Pop()
 		}
 	}
 	if !w.isRunning() && len(coalescedLogs) > 0 {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -986,7 +986,7 @@ func (w *worker) commitTransactions(env *environment, txs *types.TransactionsByP
 		default:
 			// Strange error, discard the transaction and get the next in line (note, the
 			// nonce-too-high clause will prevent us from executing in vain).
-			log.Debug("Transaction failed, account skipped", "hash", tx.Hash(), "err", err)
+			log.Info("Transaction failed, account skipped", "hash", tx.Hash(), "err", err)
 			txs.Pop()
 		}
 	}


### PR DESCRIPTION
Core changes:
- discard invalid tx after `commitTransaction`, refer to [go-ethereum](https://github.com/ethereum/go-ethereum/pull/27038)
- fix the case gasPrice = 0 when `estimateGas`
- `gasLimit` should cover l1Cost when validating in txpool
- fix l1Cost when replacing tx in txpool, refer to [code](https://github.com/ethereum-optimism/op-geth/blob/336d284b606ec4792a605932201b97f04981db9d/core/txpool/legacypool/legacypool.go#L658)