### PR TITLE
[R4R]-fix: eth_estimateGas

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -628,7 +628,6 @@ func (pool *TxPool) toJournal() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	fmt.Println("pool.validateTx:")
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.
@@ -679,7 +678,6 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
-	fmt.Println("tx.From(), tx.To(), tx.Nonce()", from, tx.To(), tx.Nonce())
 	// Drop non-local transactions under our own minimal accepted gas price or tip
 	if tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
@@ -781,7 +779,6 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 			return core.ErrInsufficientGasForL1Cost
 		}
 	} else if tx.Type() == types.DynamicFeeTxType {
-		fmt.Println("tx.GasTipCap():", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap())
 		// When feecap is smaller than basefee, submission is meaningless.
 		// Report an error quickly instead of getting stuck in txpool.
 		if tx.GasFeeCap().Cmp(baseFee) < 0 { // Consistent with legacy tx verification
@@ -792,7 +789,6 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		// dynamicBaseFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx
 		effectiveGas := cmath.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
 		dynamicFeeTxL1Cost := new(big.Int).Mul(effectiveGas, gasRemaining)
-		fmt.Println("effectiveGas:", effectiveGas, "gasRemaining:", gasRemaining, "dynamicFeeTxL1Cost:", dynamicFeeTxL1Cost, "l1Cost:", l1Cost)
 		if l1Cost != nil && dynamicFeeTxL1Cost.Cmp(l1Cost) <= 0 {
 			return core.ErrInsufficientGasForL1Cost
 		}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -628,7 +628,7 @@ func (pool *TxPool) toJournal() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	log.Info("=================pool.validateTx:")
+	fmt.Println("pool.validateTx:")
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.
@@ -679,7 +679,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
-	log.Info("=============tx.From(), tx.To(), tx.Nonce()", "tx.From()", from, "tx.To()", tx.To(), "tx.Nonce()", tx.Nonce())
+	fmt.Println("tx.From(), tx.To(), tx.Nonce()", from, tx.To(), tx.Nonce())
 	// Drop non-local transactions under our own minimal accepted gas price or tip
 	if tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
@@ -781,7 +781,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 			return core.ErrInsufficientGasForL1Cost
 		}
 	} else if tx.Type() == types.DynamicFeeTxType {
-		log.Info("=============DynamicFeeTxType", "tx.GasTipCap():", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap())
+		fmt.Println("tx.GasTipCap():", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap())
 		// When feecap is smaller than basefee, submission is meaningless.
 		// Report an error quickly instead of getting stuck in txpool.
 		if tx.GasFeeCap().Cmp(baseFee) < 0 { // Consistent with legacy tx verification
@@ -792,7 +792,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		// dynamicBaseFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx
 		effectiveGas := cmath.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
 		dynamicFeeTxL1Cost := new(big.Int).Mul(effectiveGas, gasRemaining)
-		log.Info("=============dynamicFeeTxL1Cost", "effectiveGas:", effectiveGas, "gasRemaining:", gasRemaining, "dynamicFeeTxL1Cost:", dynamicFeeTxL1Cost, "l1Cost:", l1Cost)
+		fmt.Println("effectiveGas:", effectiveGas, "gasRemaining:", gasRemaining, "dynamicFeeTxL1Cost:", dynamicFeeTxL1Cost, "l1Cost:", l1Cost)
 		if l1Cost != nil && dynamicFeeTxL1Cost.Cmp(l1Cost) <= 0 {
 			return core.ErrInsufficientGasForL1Cost
 		}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -628,7 +628,7 @@ func (pool *TxPool) toJournal() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-	fmt.Println("pool.validateTx:")
+	log.Info("=================pool.validateTx:")
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.
@@ -679,7 +679,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
-	fmt.Println("tx.From(), tx.To(), tx.Nonce()", from, tx.To(), tx.Nonce())
+	log.Info("=============tx.From(), tx.To(), tx.Nonce()", "tx.From()", from, "tx.To()", tx.To(), "tx.Nonce()", tx.Nonce())
 	// Drop non-local transactions under our own minimal accepted gas price or tip
 	if tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
@@ -781,7 +781,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 			return core.ErrInsufficientGasForL1Cost
 		}
 	} else if tx.Type() == types.DynamicFeeTxType {
-		fmt.Println("tx.GasTipCap():", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap())
+		log.Info("=============DynamicFeeTxType", "tx.GasTipCap():", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap())
 		// When feecap is smaller than basefee, submission is meaningless.
 		// Report an error quickly instead of getting stuck in txpool.
 		if tx.GasFeeCap().Cmp(baseFee) < 0 { // Consistent with legacy tx verification
@@ -792,7 +792,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		// dynamicBaseFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx
 		effectiveGas := cmath.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
 		dynamicFeeTxL1Cost := new(big.Int).Mul(effectiveGas, gasRemaining)
-		fmt.Println("effectiveGas:", effectiveGas, "gasRemaining:", gasRemaining, "dynamicFeeTxL1Cost:", dynamicFeeTxL1Cost, "l1Cost:", l1Cost)
+		log.Info("=============dynamicFeeTxL1Cost", "effectiveGas:", effectiveGas, "gasRemaining:", gasRemaining, "dynamicFeeTxL1Cost:", dynamicFeeTxL1Cost, "l1Cost:", l1Cost)
 		if l1Cost != nil && dynamicFeeTxL1Cost.Cmp(l1Cost) <= 0 {
 			return core.ErrInsufficientGasForL1Cost
 		}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -628,6 +628,7 @@ func (pool *TxPool) toJournal() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
+	fmt.Println("pool.validateTx:")
 	// No unauthenticated deposits allowed in the transaction pool.
 	// This is for spam protection, not consensus,
 	// as the external engine-API user authenticates deposits.
@@ -678,6 +679,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if err != nil {
 		return ErrInvalidSender
 	}
+	fmt.Println("tx.From(), tx.To(), tx.Nonce()", from, tx.To(), tx.Nonce())
 	// Drop non-local transactions under our own minimal accepted gas price or tip
 	if tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
@@ -779,6 +781,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 			return core.ErrInsufficientGasForL1Cost
 		}
 	} else if tx.Type() == types.DynamicFeeTxType {
+		fmt.Println("tx.GasTipCap():", tx.GasTipCap(), "tx.GasFeeCap()", tx.GasFeeCap())
 		// When feecap is smaller than basefee, submission is meaningless.
 		// Report an error quickly instead of getting stuck in txpool.
 		if tx.GasFeeCap().Cmp(baseFee) < 0 { // Consistent with legacy tx verification
@@ -789,6 +792,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		// dynamicBaseFeeTxL1Cost gas used to cover L1 Cost for dynamic fee tx
 		effectiveGas := cmath.BigMin(new(big.Int).Add(tx.GasTipCap(), baseFee), tx.GasFeeCap())
 		dynamicFeeTxL1Cost := new(big.Int).Mul(effectiveGas, gasRemaining)
+		fmt.Println("effectiveGas:", effectiveGas, "gasRemaining:", gasRemaining, "dynamicFeeTxL1Cost:", dynamicFeeTxL1Cost, "l1Cost:", l1Cost)
 		if l1Cost != nil && dynamicFeeTxL1Cost.Cmp(l1Cost) <= 0 {
 			return core.ErrInsufficientGasForL1Cost
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -80,7 +80,6 @@ func (s *EthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 
 // MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions.
 func (s *EthereumAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error) {
-	fmt.Println("EthereumAPI.MaxPriorityFeePerGas")
 	tipcap, err := s.b.SuggestGasTipCap(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -80,6 +80,7 @@ func (s *EthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) {
 
 // MaxPriorityFeePerGas returns a suggestion for a gas tip cap for dynamic fee transactions.
 func (s *EthereumAPI) MaxPriorityFeePerGas(ctx context.Context) (*hexutil.Big, error) {
+	fmt.Println("EthereumAPI.MaxPriorityFeePerGas")
 	tipcap, err := s.b.SuggestGasTipCap(ctx)
 	if err != nil {
 		return nil, err
@@ -1290,7 +1291,8 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		allowance := new(big.Int).Div(available, feeCap)
 
 		// If the allowance is larger than maximum uint64, skip checking
-		if allowance.IsUint64() && hi > allowance.Uint64() {
+		// If the runMode is core.GasEstimationWithSkipCheckBalanceMode, skip checking
+		if runMode != core.GasEstimationWithSkipCheckBalanceMode && allowance.IsUint64() && hi > allowance.Uint64() {
 			transfer := args.Value
 			if transfer == nil {
 				transfer = new(hexutil.Big)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1252,7 +1252,9 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	}
 
 	runMode := core.GasEstimationMode
-	if args.GasPrice == nil && args.MaxFeePerGas == nil && args.MaxPriorityFeePerGas == nil {
+	if (args.GasPrice == nil || args.GasPrice.ToInt().Sign() == 0) && // GasPrice is nil or zero AND
+		(args.MaxFeePerGas == nil || args.MaxFeePerGas.ToInt().Sign() == 0) && // MaxFeePerGas is nil or zero AND
+		(args.MaxPriorityFeePerGas == nil || args.MaxPriorityFeePerGas.ToInt().Sign() == 0) { // MaxPriorityFeePerGas is nil or zero
 		runMode = core.GasEstimationWithSkipCheckBalanceMode
 	}
 

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -259,7 +259,7 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 	// use suggested gasPrice for estimateGas to calculate gasUsed
 	if runMode == core.GasEstimationMode || runMode == core.GasEstimationWithSkipCheckBalanceMode {
 		// use default gasPrice if user does not set gasPrice or gasPrice is 0
-		if args.GasPrice == nil && gasPrice.Cmp(common.Big0) == 0 {
+		if args.GasPrice == nil || gasPrice.Cmp(common.Big0) == 0 {
 			gasPrice = gasPriceForEstimate.ToInt()
 		}
 		// use gasTipCap to set gasFeeCap

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -280,13 +280,6 @@ func (args *TransactionArgs) ToMessage(globalGasCap uint64, baseFee *big.Int, ru
 			gasFeeCap = gasPriceForEstimate.ToInt()
 			gasTipCap = gasPriceForEstimate.ToInt()
 		}
-
-		if gasPrice.Cmp(gasPriceForEstimate.ToInt()) < 0 {
-			gasPrice = gasPriceForEstimate.ToInt()
-		}
-		if gasFeeCap.Cmp(gasPriceForEstimate.ToInt()) < 0 {
-			gasFeeCap = gasPriceForEstimate.ToInt()
-		}
 	}
 
 	value := new(big.Int)


### PR DESCRIPTION
1. Removed an issue where gasPrice or gasFeeCap would default to baseFee when it was lower than baseFee, as this would cause estimateGas to succeed but eth_call to fail with the same parameters
2. When the user does not set the gasPrice or 1559 parameters, the from account balance should not be verified, otherwise the estimateGas will not be executed.