### PR TITLE
[R4R]-fix: estimate gas evm error

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -661,7 +661,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 			return 0, err
 		}
 		if failed {
-			if result != nil && result.Err != vm.ErrOutOfGas {
+			if result != nil && !errors.Is(result.Err, vm.ErrOutOfGas) {
 				if len(result.Revert()) > 0 {
 					return 0, newRevertError(result)
 				}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1326,7 +1326,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	// Execute the binary search and hone in on an executable gas limit
 	for lo+1 < hi {
 		mid := (hi + lo) / 2
-		failed, _, err := executable(mid)
+		failed, result, err := executable(mid)
 
 		// If the error is not nil(consensus error), it means the provided message
 		// call or transaction will never be accepted no matter how much gas it is
@@ -1334,6 +1334,14 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 		if err != nil {
 			return 0, err
 		}
+
+		if result != nil && result.Err != vm.ErrOutOfGas {
+			if len(result.Revert()) > 0 {
+				return 0, newRevertError(result)
+			}
+			return 0, result.Err
+		}
+
 		if failed {
 			lo = mid
 		} else {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1335,7 +1335,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 			return 0, err
 		}
 
-		if result != nil && result.Err != vm.ErrOutOfGas {
+		if result != nil && !errors.Is(result.Err, vm.ErrOutOfGas) {
 			if len(result.Revert()) > 0 {
 				return 0, newRevertError(result)
 			}
@@ -1355,7 +1355,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 			return 0, err
 		}
 		if failed {
-			if result != nil && result.Err != vm.ErrOutOfGas {
+			if result != nil && !errors.Is(result.Err, vm.ErrOutOfGas) {
 				if len(result.Revert()) > 0 {
 					return 0, newRevertError(result)
 				}


### PR DESCRIPTION
When calling eth_estimateGas, if the EVM throws an error, it will result in the program throwing an "**_insufficient funds for gas * price + value_**" error instead of the correct EVM error.

**Cause:** When estimating gas in the layer 2, it includes gas cost from the layer 1. This causes a slight shortage when estimating gas using the user's entire balance. Additionally, during the re-estimation process, if an EVM error occurs but is not an out-of-gas error, it will be ignored. This ultimately leads to the entire estimation process failing to correctly throw an EVM error. Therefore, each estimation should include a check for an EVM result. If the result is not empty and not an out-of-gas error, the estimation should be terminated, and an exception should be thrown.

**Reproduction steps:** Deploy an ERC20 contract and use the transfer function. Test with three different accounts to verify that the **_ERC20InsufficientBalance_** error is correctly thrown. The balances of the three accounts are _0 MNT, 0.1 MNT, and 1000 MNT_, respectively.