### PR TITLE
[R4R] refactor: depositWithNonce && remove duplicate signer

### DIFF
--- a/core/types/transaction_marshalling_test.go
+++ b/core/types/transaction_marshalling_test.go
@@ -77,4 +77,27 @@ func TestTransactionUnmarshalJSON(t *testing.T) {
 			}
 		})
 	}
+
+	tests = []struct {
+		name          string
+		json          string
+		expectedError string
+	}{
+		{
+			name: "Valid deposit sender",
+			json: `{"type":"0x7e","nonce":"0x1","gas": "0x1234", "gasPrice":null,"maxPriorityFeePerGas":null,"maxFeePerGas":null,"value":"0x1","input":"0x616263646566","v":null,"r":null,"s":null,"to":null,"sourceHash":"0x0000000000000000000000000000000000000000000000000000000000000000","from":"0x0000000000000000000000000000000000000001","hash":"0xa4341f3db4363b7ca269a8538bd027b2f8784f84454ca917668642d5f6dffdf9"}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var parsedTx = &Transaction{}
+			err := json.Unmarshal([]byte(test.json), &parsedTx)
+			require.NoError(t, err)
+
+			signer := NewLondonSigner(big.NewInt(123))
+			sender, err := signer.Sender(parsedTx)
+			require.NoError(t, err)
+			require.Equal(t, common.HexToAddress("0x1"), sender)
+		})
+	}
 }


### PR DESCRIPTION
1. When the nonce of a deposit transaction is non-nil, the inner transaction will be decoded as type `depositTxWithNonce` in `transaction_marshalling.go`，this only affects people using the op-geth ethclient to retrieve and parse transactions from the RPC API, not any functionality of op-geth itself.  Detail: https://github.com/ethereum-optimism/op-geth/commit/1ee4f9ff4596f0ab66b3ad57bb4ceca8d9af3afc
2. remove duplication in eip2930 signer. Detail: https://github.com/ethereum-optimism/op-geth/commit/80b76a952739b27d04a71932649a8e9077c32cb8