### PR TITLE
eth/gasprice: use the same model as Op for priority fee suggestion

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -161,6 +161,8 @@ var (
 		utils.GpoPercentileFlag,
 		utils.GpoMaxGasPriceFlag,
 		utils.GpoIgnoreGasPriceFlag,
+		utils.GpoOpPatternFlag,
+		utils.GpoMinSuggestedPriorityFeeFlag,
 		utils.MinerNotifyFullFlag,
 		utils.RollupSequencerHTTPFlag,
 		utils.RollupHistoricalRPCFlag,

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -161,7 +161,6 @@ var (
 		utils.GpoPercentileFlag,
 		utils.GpoMaxGasPriceFlag,
 		utils.GpoIgnoreGasPriceFlag,
-		utils.GpoOpPatternFlag,
 		utils.GpoMinSuggestedPriorityFeeFlag,
 		utils.MinerNotifyFullFlag,
 		utils.RollupSequencerHTTPFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -973,6 +973,18 @@ var (
 		Value:    ethconfig.Defaults.GPO.IgnorePrice.Int64(),
 		Category: flags.GasPriceCategory,
 	}
+	GpoOpPatternFlag = &cli.BoolFlag{
+		Name:     "gpo.oppattern",
+		Usage:    "Enable Optimism fee suggestion pattern",
+		Value:    ethconfig.Defaults.GPO.OpPattern,
+		Category: flags.GasPriceCategory,
+	}
+	GpoMinSuggestedPriorityFeeFlag = &cli.Int64Flag{
+		Name:     "gpo.minsuggestedpriorityfee",
+		Usage:    "Minimum transaction priority fee to suggest. Used on OP chains when blocks are not full.",
+		Value:    ethconfig.Defaults.GPO.MinSuggestedPriorityFee.Int64(),
+		Category: flags.GasPriceCategory,
+	}
 
 	// Rollup Flags
 	RollupSequencerHTTPFlag = &cli.StringFlag{
@@ -1668,6 +1680,12 @@ func setGPO(ctx *cli.Context, cfg *gasprice.Config, light bool) {
 	}
 	if ctx.IsSet(GpoIgnoreGasPriceFlag.Name) {
 		cfg.IgnorePrice = big.NewInt(ctx.Int64(GpoIgnoreGasPriceFlag.Name))
+	}
+	if ctx.IsSet(GpoOpPatternFlag.Name) {
+		cfg.OpPattern = ctx.Bool(GpoOpPatternFlag.Name)
+	}
+	if ctx.IsSet(GpoMinSuggestedPriorityFeeFlag.Name) {
+		cfg.MinSuggestedPriorityFee = big.NewInt(ctx.Int64(GpoMinSuggestedPriorityFeeFlag.Name))
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -973,12 +973,6 @@ var (
 		Value:    ethconfig.Defaults.GPO.IgnorePrice.Int64(),
 		Category: flags.GasPriceCategory,
 	}
-	GpoOpPatternFlag = &cli.BoolFlag{
-		Name:     "gpo.oppattern",
-		Usage:    "Enable Optimism fee suggestion pattern",
-		Value:    ethconfig.Defaults.GPO.OpPattern,
-		Category: flags.GasPriceCategory,
-	}
 	GpoMinSuggestedPriorityFeeFlag = &cli.Int64Flag{
 		Name:     "gpo.minsuggestedpriorityfee",
 		Usage:    "Minimum transaction priority fee to suggest. Used on OP chains when blocks are not full.",
@@ -1680,9 +1674,6 @@ func setGPO(ctx *cli.Context, cfg *gasprice.Config, light bool) {
 	}
 	if ctx.IsSet(GpoIgnoreGasPriceFlag.Name) {
 		cfg.IgnorePrice = big.NewInt(ctx.Int64(GpoIgnoreGasPriceFlag.Name))
-	}
-	if ctx.IsSet(GpoOpPatternFlag.Name) {
-		cfg.OpPattern = ctx.Bool(GpoOpPatternFlag.Name)
 	}
 	if ctx.IsSet(GpoMinSuggestedPriorityFeeFlag.Name) {
 		cfg.MinSuggestedPriorityFee = big.NewInt(ctx.Int64(GpoMinSuggestedPriorityFeeFlag.Name))

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -409,7 +409,7 @@ func (b *EthAPIBackend) SyncProgress() ethereum.SyncProgress {
 }
 
 func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	return big.NewInt(0), nil
+	return b.gpo.SuggestTipCap(ctx)
 }
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -270,11 +270,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}
-	gpoParams := config.GPO
-	if gpoParams.Default == nil {
-		gpoParams.Default = config.Miner.GasPrice
-	}
-	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
+	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, config.GPO)
 
 	// Setup DNS discovery iterators.
 	dnsclient := dnsdisc.NewClient(dnsdisc.Config{})

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -270,7 +270,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if eth.APIBackend.allowUnprotectedTxs {
 		log.Info("Unprotected transactions allowed")
 	}
-	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, config.GPO)
+	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, config.GPO, config.Miner.GasPrice)
 
 	// Setup DNS discovery iterators.
 	dnsclient := dnsdisc.NewClient(dnsdisc.Config{})

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -49,7 +49,6 @@ var FullNodeGPO = gasprice.Config{
 	MaxBlockHistory:         1024,
 	MaxPrice:                gasprice.DefaultMaxPrice,
 	IgnorePrice:             gasprice.DefaultIgnorePrice,
-	OpPattern:               gasprice.DefaultOpPattern,
 	MinSuggestedPriorityFee: gasprice.DefaultMinSuggestedPriorityFee,
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -43,12 +43,14 @@ import (
 
 // FullNodeGPO contains default gasprice oracle settings for full node.
 var FullNodeGPO = gasprice.Config{
-	Blocks:           20,
-	Percentile:       60,
-	MaxHeaderHistory: 1024,
-	MaxBlockHistory:  1024,
-	MaxPrice:         gasprice.DefaultMaxPrice,
-	IgnorePrice:      gasprice.DefaultIgnorePrice,
+	Blocks:                  20,
+	Percentile:              60,
+	MaxHeaderHistory:        1024,
+	MaxBlockHistory:         1024,
+	MaxPrice:                gasprice.DefaultMaxPrice,
+	IgnorePrice:             gasprice.DefaultIgnorePrice,
+	OpPattern:               gasprice.DefaultOpPattern,
+	MinSuggestedPriorityFee: gasprice.DefaultMinSuggestedPriorityFee,
 }
 
 // LightClientGPO contains default gasprice oracle settings for light client.

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -59,7 +59,7 @@ func TestFeeHistory(t *testing.T) {
 			MaxBlockHistory:  c.maxBlock,
 		}
 		backend := newTestBackend(t, big.NewInt(16), c.pending)
-		oracle := NewOracle(backend, config)
+		oracle := NewOracle(backend, config, nil)
 
 		first, reward, baseFee, ratio, err := oracle.FeeHistory(context.Background(), c.count, c.last, c.percent)
 		backend.teardown()

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -38,7 +38,7 @@ var (
 	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
 	DefaultIgnorePrice = big.NewInt(2 * params.Wei)
 
-	DefaultMinSuggestedPriorityFee = big.NewInt(1e6 * params.Wei) // 0.001 gwei, for Optimism fee suggestion
+	DefaultMinSuggestedPriorityFee = big.NewInt(1e5 * params.Wei) // 0.0001 gwei, for Optimism fee suggestion
 )
 
 type Config struct {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -121,7 +121,7 @@ func NewOracle(backend OracleBackend, params Config, startPrice *big.Int) *Oracl
 	}
 	if startPrice == nil || startPrice.Int64() < 0 {
 		log.Warn("Sanitizing invalid gasprice oracle start price", "provided", startPrice, "updated", 0)
-		startPrice = big.NewInt(0)
+		startPrice = new(big.Int)
 	}
 
 	cache := lru.NewCache[cacheKey, processedFees](2048)

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -119,8 +119,7 @@ func NewOracle(backend OracleBackend, params Config, startPrice *big.Int) *Oracl
 		maxBlockHistory = 1
 		log.Warn("Sanitizing invalid gasprice oracle max block history", "provided", params.MaxBlockHistory, "updated", maxBlockHistory)
 	}
-	if startPrice == nil || startPrice.Int64() < 0 {
-		log.Warn("Sanitizing invalid gasprice oracle start price", "provided", startPrice, "updated", 0)
+	if startPrice == nil {
 		startPrice = new(big.Int)
 	}
 

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -187,6 +187,7 @@ func TestSuggestTipCap(t *testing.T) {
 		Blocks:     3,
 		Percentile: 60,
 		Default:    big.NewInt(params.GWei),
+		OpPattern:  false,
 	}
 	var cases = []struct {
 		fork   *big.Int // London fork number

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -186,7 +186,6 @@ func TestSuggestTipCap(t *testing.T) {
 	config := Config{
 		Blocks:     3,
 		Percentile: 60,
-		Default:    big.NewInt(params.GWei),
 		OpPattern:  false,
 	}
 	var cases = []struct {
@@ -201,7 +200,7 @@ func TestSuggestTipCap(t *testing.T) {
 	}
 	for _, c := range cases {
 		backend := newTestBackend(t, c.fork, false)
-		oracle := NewOracle(backend, config)
+		oracle := NewOracle(backend, config, big.NewInt(params.GWei))
 
 		// The gas price sampled is: 32G, 31G, 30G, 29G, 28G, 27G
 		got, err := oracle.SuggestTipCap(context.Background())

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -186,7 +186,6 @@ func TestSuggestTipCap(t *testing.T) {
 	config := Config{
 		Blocks:     3,
 		Percentile: 60,
-		OpPattern:  false,
 	}
 	var cases = []struct {
 		fork   *big.Int // London fork number

--- a/eth/gasprice/optimism-gasprice.go
+++ b/eth/gasprice/optimism-gasprice.go
@@ -1,0 +1,110 @@
+package gasprice
+
+import (
+	"context"
+	"math/big"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// SuggestOptimismPriorityFee returns a max priority fee value that can be used such that newly
+// created transactions have a very high chance to be included in the following blocks, using a
+// simplified and more predictable algorithm appropriate for chains like Optimism with a single
+// known block builder.
+//
+// In the typical case, which results whenever the last block had room for more transactions, this
+// function returns a minimum suggested priority fee value. Otherwise it returns the higher of this
+// minimum suggestion or 10% over the median effective priority fee from the last block.
+//
+// Rationale: For a chain such as Optimism where there is a single block builder whose behavior is
+// known, we know priority fee (as long as it is non-zero) has no impact on the probability for tx
+// inclusion as long as there is capacity for it in the block. In this case then, there's no reason
+// to return any value higher than some fixed minimum. Blocks typically reach capacity only under
+// extreme events such as airdrops, meaning predicting whether the next block is going to be at
+// capacity is difficult *except* in the case where we're already experiencing the increased demand
+// from such an event. We therefore expect whether the last known block is at capacity to be one of
+// the best predictors of whether the next block is likely to be at capacity. (An even better
+// predictor is to look at the state of the transaction pool, but we want an algorithm that works
+// even if the txpool is private or unavailable.)
+//
+// In the event the next block may be at capacity, the algorithm should allow for average fees to
+// rise in order to reach a market price that appropriately reflects demand. We accomplish this by
+// returning a suggestion that is a significant amount (10%) higher than the median effective
+// priority fee from the previous block.
+func (oracle *Oracle) SuggestOptimismPriorityFee(ctx context.Context, h *types.Header, headHash common.Hash) *big.Int {
+	suggestion := new(big.Int).Set(oracle.minSuggestedPriorityFee)
+
+	// find the maximum gas used by any of the transactions in the block to use as the capacity
+	// margin
+	receipts, err := oracle.backend.GetReceipts(ctx, headHash)
+	if receipts == nil || err != nil {
+		log.Error("failed to get block receipts", "err", err)
+		return suggestion
+	}
+	var maxTxGasUsed uint64
+	for i := range receipts {
+		gu := receipts[i].GasUsed
+		if gu > maxTxGasUsed {
+			maxTxGasUsed = gu
+		}
+	}
+
+	// sanity check the max gas used value
+	if maxTxGasUsed > h.GasLimit {
+		log.Error("found tx consuming more gas than the block limit", "gas", maxTxGasUsed)
+		return suggestion
+	}
+
+	if h.GasUsed+maxTxGasUsed > h.GasLimit {
+		// A block is "at capacity" if, when it is built, there is a pending tx in the txpool that
+		// could not be included because the block's gas limit would be exceeded. Since we don't
+		// have access to the txpool, we instead adopt the following heuristic: consider a block as
+		// at capacity if the total gas consumed by its transactions is within max-tx-gas-used of
+		// the block limit, where max-tx-gas-used is the most gas used by any one transaction
+		// within the block. This heuristic is almost perfectly accurate when transactions always
+		// consume the same amount of gas, but becomes less accurate as tx gas consumption begins
+		// to vary. The typical error is we assume a block is at capacity when it was not because
+		// max-tx-gas-used will in most cases over-estimate the "capacity margin". But it's better
+		// to err on the side of returning a higher-than-needed suggestion than a lower-than-needed
+		// one in order to satisfy our desire for high chance of inclusion and rising fees under
+		// high demand.
+		block, err := oracle.backend.BlockByNumber(ctx, rpc.BlockNumber(h.Number.Int64()))
+		if block == nil || err != nil {
+			log.Error("failed to get last block", "err", err)
+			return suggestion
+		}
+		baseFee := block.BaseFee()
+		txs := block.Transactions()
+		if len(txs) == 0 {
+			log.Error("block was at capacity but doesn't have transactions")
+			return suggestion
+		}
+		tips := bigIntArray(make([]*big.Int, len(txs)))
+		for i := range txs {
+			tips[i] = txs[i].EffectiveGasTipValue(baseFee)
+		}
+		sort.Sort(tips)
+		median := tips[len(tips)/2]
+		newSuggestion := new(big.Int).Add(median, new(big.Int).Div(median, big.NewInt(10)))
+		// use the new suggestion only if it's bigger than the minimum
+		if newSuggestion.Cmp(suggestion) > 0 {
+			suggestion = newSuggestion
+		}
+	}
+
+	// the suggestion should be capped by oracle.maxPrice
+	if suggestion.Cmp(oracle.maxPrice) > 0 {
+		suggestion.Set(oracle.maxPrice)
+	}
+
+	oracle.cacheLock.Lock()
+	oracle.lastHead = headHash
+	oracle.lastPrice = suggestion
+	oracle.cacheLock.Unlock()
+
+	return new(big.Int).Set(suggestion)
+}

--- a/eth/gasprice/optimism-gasprice_test.go
+++ b/eth/gasprice/optimism-gasprice_test.go
@@ -135,7 +135,7 @@ func TestSuggestOptimismPriorityFee(t *testing.T) {
 	}
 	for i, c := range cases {
 		backend := newOpTestBackend(t, c.txdata)
-		oracle := NewOracle(backend, Config{MinSuggestedPriorityFee: minSuggestion})
+		oracle := NewOracle(backend, Config{MinSuggestedPriorityFee: minSuggestion}, big.NewInt(params.GWei))
 		got := oracle.SuggestOptimismPriorityFee(context.Background(), backend.block.Header(), backend.block.Hash())
 		if got.Cmp(c.want) != 0 {
 			t.Errorf("Gas price mismatch for test case %d: want %d, got %d", i, c.want, got)

--- a/eth/gasprice/optimism-gasprice_test.go
+++ b/eth/gasprice/optimism-gasprice_test.go
@@ -1,0 +1,144 @@
+// Copyright 2020 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package gasprice
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+const (
+	blockGasLimit = params.TxGas * 3
+)
+
+type testTxData struct {
+	priorityFee int64
+	gasLimit    uint64
+}
+
+type opTestBackend struct {
+	block    *types.Block
+	receipts []*types.Receipt
+}
+
+func (b *opTestBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
+	panic("not implemented")
+}
+
+func (b *opTestBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
+	return b.block, nil
+}
+
+func (b *opTestBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
+	return b.receipts, nil
+}
+
+func (b *opTestBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
+	panic("not implemented")
+}
+
+func (b *opTestBackend) ChainConfig() *params.ChainConfig {
+	return params.OptimismTestConfig
+}
+
+func (b *opTestBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
+	return nil
+}
+
+var _ OracleBackend = (*opTestBackend)(nil)
+
+func newOpTestBackend(t *testing.T, txs []testTxData) *opTestBackend {
+	var (
+		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		signer = types.LatestSigner(params.TestChainConfig)
+	)
+	// only the most recent block is considered for optimism priority fee suggestions, so this is
+	// where we add the test transactions
+	ts := []*types.Transaction{}
+	rs := []*types.Receipt{}
+	header := types.Header{}
+	header.GasLimit = blockGasLimit
+	var nonce uint64
+	for _, tx := range txs {
+		txdata := &types.DynamicFeeTx{
+			ChainID:   params.TestChainConfig.ChainID,
+			Nonce:     nonce,
+			To:        &common.Address{},
+			Gas:       params.TxGas,
+			GasFeeCap: big.NewInt(100 * params.GWei),
+			GasTipCap: big.NewInt(tx.priorityFee),
+			Data:      []byte{},
+		}
+		t := types.MustSignNewTx(key, signer, txdata)
+		ts = append(ts, t)
+		r := types.Receipt{}
+		r.GasUsed = tx.gasLimit
+		header.GasUsed += r.GasUsed
+		rs = append(rs, &r)
+		nonce++
+	}
+	hasher := trie.NewStackTrie(nil)
+	b := types.NewBlock(&header, ts, nil, nil, hasher)
+	return &opTestBackend{block: b, receipts: rs}
+}
+
+func TestSuggestOptimismPriorityFee(t *testing.T) {
+	minSuggestion := new(big.Int).SetUint64(1e8 * params.Wei)
+	cases := []struct {
+		txdata []testTxData
+		want   *big.Int
+	}{
+		{
+			// block well under capacity, expect min priority fee suggestion
+			txdata: []testTxData{{params.GWei, 21000}},
+			want:   minSuggestion,
+		},
+		{
+			// 2 txs, still under capacity, expect min priority fee suggestion
+			txdata: []testTxData{{params.GWei, 21000}, {params.GWei, 21000}},
+			want:   minSuggestion,
+		},
+		{
+			// 2 txs w same priority fee (1 gwei), but second tx puts it right over capacity
+			txdata: []testTxData{{params.GWei, 21000}, {params.GWei, 21001}},
+			want:   big.NewInt(1100000000), // 10 percent over 1 gwei, the median
+		},
+		{
+			// 3 txs, full block. return 10% over the median tx (10 gwei * 10% == 11 gwei)
+			txdata: []testTxData{{10 * params.GWei, 21000}, {1 * params.GWei, 21000}, {100 * params.GWei, 21000}},
+			want:   big.NewInt(11 * params.GWei),
+		},
+	}
+	for i, c := range cases {
+		backend := newOpTestBackend(t, c.txdata)
+		oracle := NewOracle(backend, Config{MinSuggestedPriorityFee: minSuggestion})
+		got := oracle.SuggestOptimismPriorityFee(context.Background(), backend.block.Header(), backend.block.Hash())
+		if got.Cmp(c.want) != 0 {
+			t.Errorf("Gas price mismatch for test case %d: want %d, got %d", i, c.want, got)
+		}
+	}
+}

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -277,7 +277,7 @@ func (b *LesApiBackend) ProtocolVersion() int {
 }
 
 func (b *LesApiBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	return big.NewInt(0), nil
+	return b.gpo.SuggestTipCap(ctx)
 }
 
 func (b *LesApiBackend) FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {

--- a/les/client.go
+++ b/les/client.go
@@ -189,7 +189,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	}
 
 	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, leth, nil}
-	leth.ApiBackend.gpo = gasprice.NewOracle(leth.ApiBackend, config.GPO)
+	leth.ApiBackend.gpo = gasprice.NewOracle(leth.ApiBackend, config.GPO, config.Miner.GasPrice)
 
 	leth.handler = newClientHandler(config.UltraLightServers, config.UltraLightFraction, checkpoint, leth)
 	if leth.handler.ulc != nil {

--- a/les/client.go
+++ b/les/client.go
@@ -189,11 +189,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*LightEthereum, error) {
 	}
 
 	leth.ApiBackend = &LesApiBackend{stack.Config().ExtRPCEnabled(), stack.Config().AllowUnprotectedTxs, leth, nil}
-	gpoParams := config.GPO
-	if gpoParams.Default == nil {
-		gpoParams.Default = config.Miner.GasPrice
-	}
-	leth.ApiBackend.gpo = gasprice.NewOracle(leth.ApiBackend, gpoParams)
+	leth.ApiBackend.gpo = gasprice.NewOracle(leth.ApiBackend, config.GPO)
 
 	leth.handler = newClientHandler(config.UltraLightServers, config.UltraLightFraction, checkpoint, leth)
 	if leth.handler.ulc != nil {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -72,7 +72,7 @@ type Config struct {
 // DefaultConfig contains default settings for miner.
 var DefaultConfig = Config{
 	GasCeil:  core.DefaultMantleBlockGasLimit,
-	GasPrice: big.NewInt(params.GWei),
+	GasPrice: big.NewInt(params.GWei / 1000),
 
 	// The default recommit time is chosen as two seconds since
 	// consensus-layer usually will wait a half slot of time(6s)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We have made some changes to `eth_maxPriorityFeePerGas` api that it returns a constant zero.
Revert it and use the same way to suggest as Optimism.
Reset `miner.gasprice` default value from `1gwei` to `0.001gwei`

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
```
=== RUN   TestFeeHistory
--- PASS: TestFeeHistory (0.12s)
=== RUN   TestSuggestTipCap
--- PASS: TestSuggestTipCap (0.04s)
=== RUN   TestSuggestOptimismPriorityFee
--- PASS: TestSuggestOptimismPriorityFee (0.00s)
PASS
ok      github.com/ethereum/go-ethereum/eth/gasprice    1.068s
```
<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
