### PR TITLE
chore: update sepolia arsia upgrade time

### DIFF
--- a/params/mantle.go
+++ b/params/mantle.go
@@ -34,7 +34,7 @@ var (
 		MantleEverestTime:     u64Ptr(1_737_010_800),
 		MantleSkadiTime:       u64Ptr(1_752_649_200),
 		MantleLimbTime:        u64Ptr(1_764_745_200),
-		MantleArsiaTime:       u64Ptr(1_773_212_400),
+		MantleArsiaTime:       u64Ptr(1_774_422_000),
 	}
 
 	// Starting from arsia, hardcoding upgrade timestamps of qa/dev/local networks are deprecated.


### PR DESCRIPTION
## Summary

- Postpone the Mantle Arsia upgrade time on Sepolia from **March 11, 2026 07:00 UTC** (`1773212400`) to **March 25, 2026 07:00 UTC** (`1774422000`), adding a 2-week delay to allow more testing and preparation before the upgrade activates on the Sepolia testnet.

## Changes

- `params/mantle.go`: Update `MantleArsiaTime` for the Sepolia config from `1_773_212_400` to `1_774_422_000`.


Made with [Cursor](https://cursor.com)