### PR TITLE
feat: derive local version from git tag instead of hardcoding

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -245,6 +245,9 @@ func buildFlags(env build.Environment, staticLinking bool, buildTags []string) (
 		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitCommit="+env.Commit)
 		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitDate="+env.Date)
 	}
+	if env.Tag != "" {
+		ld = append(ld, "-X", "github.com/ethereum/go-ethereum/internal/version.gitTag="+env.Tag)
+	}
 	// Strip DWARF on darwin. This used to be required for certain things,
 	// and there is no downside to this, so we just keep doing it.
 	if runtime.GOOS == "darwin" {

--- a/cmd/geth/misccmd.go
+++ b/cmd/geth/misccmd.go
@@ -72,7 +72,7 @@ func printVersion(ctx *cli.Context) error {
 	git, _ := version.VCS()
 
 	fmt.Println(strings.Title(clientIdentifier))
-	fmt.Println("Version:", version.WithMeta)
+	fmt.Println("Version:", version.LocalVersion())
 	if git.Commit != "" {
 		fmt.Println("Git Commit:", git.Commit)
 	}

--- a/internal/flags/helpers.go
+++ b/internal/flags/helpers.go
@@ -38,7 +38,7 @@ func NewApp(usage string) *cli.App {
 	git, _ := version.VCS()
 	app := cli.NewApp()
 	app.EnableBashCompletion = true
-	app.Version = version.WithCommit(git.Commit, git.Date)
+	app.Version = version.ShortVersion(git.Commit, git.Date)
 	app.Usage = usage
 	app.Copyright = "Copyright 2013-2025 The go-ethereum Authors"
 	app.Before = func(ctx *cli.Context) error {

--- a/internal/version/vcs.go
+++ b/internal/version/vcs.go
@@ -30,12 +30,13 @@ const (
 
 // These variables are set at build-time by the linker when the build is
 // done by build/ci.go.
-var gitCommit, gitDate string
+var gitCommit, gitDate, gitTag string
 
 // VCSInfo represents the git repository state.
 type VCSInfo struct {
 	Commit string // head commit hash
 	Date   string // commit time in YYYYMMDD format
+	Tag    string // tag pointing at HEAD (e.g. v1.5.2), from linker or build info
 	Dirty  bool
 }
 
@@ -43,7 +44,7 @@ type VCSInfo struct {
 func VCS() (VCSInfo, bool) {
 	if gitCommit != "" {
 		// Use information set by the build script if present.
-		return VCSInfo{Commit: gitCommit, Date: gitDate}, true
+		return VCSInfo{Commit: gitCommit, Date: gitDate, Tag: gitTag}, true
 	}
 	if buildInfo, ok := debug.ReadBuildInfo(); ok {
 		if buildInfo.Main.Path == ourPath {
@@ -68,6 +69,8 @@ func buildInfoVCS(info *debug.BuildInfo) (s VCSInfo, ok bool) {
 			if err == nil {
 				s.Date = t.Format(ourTimeLayout)
 			}
+		case "vcs.tag":
+			s.Tag = v.Value
 		}
 	}
 	if s.Commit != "" && s.Date != "" {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -64,6 +64,43 @@ func WithCommit(gitCommit, gitDate string) string {
 	return vsn
 }
 
+// LocalVersion returns the local/mantle version from the git tag, or a dev fallback.
+// The tag is read from VCS (linker-injected or build info vcs.tag). If no tag is present,
+// returns "dev-" plus the short commit hash when available.
+func LocalVersion() string {
+	git, ok := VCS()
+	if !ok {
+		return "dev"
+	}
+	if git.Tag != "" {
+		tag := git.Tag
+		if len(tag) > 0 && tag[0] != 'v' {
+			tag = "v" + tag
+		}
+		return tag
+	}
+	if len(git.Commit) >= 8 {
+		return "dev-" + git.Commit[:8]
+	}
+	return "dev"
+}
+
+// ShortVersion returns the string used for geth --version: LocalVersion-upstreamv<upstream>-<commit>.
+func ShortVersion(gitCommit, gitDate string) string {
+	upstream := fmt.Sprintf("v%d.%d.%d", version.Major, version.Minor, version.Patch)
+	if version.Meta != "" {
+		upstream += "-" + version.Meta
+	}
+	s := LocalVersion() + "-upstream" + upstream
+	if len(gitCommit) >= 8 {
+		s += "-" + gitCommit[:8]
+	}
+	if (version.Meta != "stable") && (gitDate != "") {
+		s += "-" + gitDate
+	}
+	return s
+}
+
 // Archive holds the textual version string used for Geth archives. e.g.
 // "1.8.11-dea1ce05" for stable releases, or "1.8.13-unstable-21c059b6" for unstable
 // releases.


### PR DESCRIPTION
## Summary

Refines geth version reporting so that the **local (Mantle) version** is derived from the git tag at build time instead of being hardcoded in code. `geth version` shows the local version (e.g. `v1.5.2`), and `geth --version` shows a combined string (e.g. `v1.5.2-upstreamv1.16.5-stable-<commit>`).

## Changes

### Version discovery from tag
- **`internal/version/vcs.go`**: Added `gitTag` linker variable and `Tag` field on `VCSInfo`. Tag is read from linker-injected value (build script) or from `debug.BuildInfo` `vcs.tag` when present.
- **`build/ci.go`**: When `env.Tag` is set, injects it via ldflags (`-X ...version.gitTag=<tag>`). `env.Tag` is already populated by `build.Env()` / `LocalEnv()` using `git tag -l --points-at HEAD`, so no extra configuration is needed for CI or `go run build/ci.go install`.

### Local version and short version
- **`internal/version/version.go`**:
  - **`LocalVersion()`**: Returns the tag (with `v` prefix if missing), or `dev-<commit>` when no tag, or `dev` when no VCS info.
  - **`ShortVersion(gitCommit, gitDate)`**: Builds the `--version` string: `LocalVersion()-upstreamv<upstream>-<commit>` (and optional date for non-stable).

### CLI usage
- **`cmd/geth/misccmd.go`**: `geth version` now prints `Version: ` using `version.LocalVersion()`.
- **`internal/flags/helpers.go`**: `geth --version` uses `version.ShortVersion(git.Commit, git.Date)` for the app version string.

## Behavior

| Build | Version (full) | --version (short) |
|-------|----------------|-------------------|
| Tagged commit (e.g. `v1.5.2`) via ci.go or ldflags | `Version: v1.5.2` | `geth version v1.5.2-upstreamv1.16.5-stable-<commit>` |
| Untagged / `go build` | `Version: dev-<commit>` or `dev` | Same local part + upstream + commit |

## Testing

- Build from a tagged commit: `go run build/ci.go install` → Version reflects the tag.
- Build without tag: `go build ./cmd/geth` → Version shows `dev-<commit>` (when VCS info is embedded).
- Optional manual tag injection: `go build -ldflags "-X ...version.gitTag=v1.5.2 ..." -o ./build/bin/geth ./cmd/geth` then run `./build/bin/geth version` and `./build/bin/geth --version`.

Made with [Cursor](https://cursor.com)