### PR TITLE
Fix EstimateTotalFee redundant state lookup and cleanup

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"math/big"
 
-	// "github.com/ethereum/go-ethereum/log"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core/state"

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -983,11 +983,17 @@ func (api *BlockChainAPI) SimulateV1(ctx context.Context, opts simOpts, blockNrO
 // there are unexpected failures. The gas limit is capped by both `args.Gas` (if non-nil &
 // non-zero) and `gasCap` (if non-zero).
 func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *override.StateOverride, blockOverrides *override.BlockOverrides, gasCap uint64) (hexutil.Uint64, error) {
-	// Retrieve the base state and mutate it with any overrides
 	state, header, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return 0, err
 	}
+	return doEstimateGasWithState(ctx, b, args, state, header, overrides, blockOverrides, gasCap)
+}
+
+// doEstimateGasWithState is the core gas estimation logic that operates on
+// pre-resolved state and header. This avoids redundant lookups when the caller
+// (e.g. EstimateTotalFee) has already resolved the block context.
+func doEstimateGasWithState(ctx context.Context, b Backend, args TransactionArgs, state *state.StateDB, header *types.Header, overrides *override.StateOverride, blockOverrides *override.BlockOverrides, gasCap uint64) (hexutil.Uint64, error) {
 	blockCtx := core.NewEVMBlockContext(header, NewChainContext(ctx, b), nil, b.ChainConfig(), state)
 	if blockOverrides != nil {
 		if err := blockOverrides.Apply(&blockCtx); err != nil {
@@ -1108,14 +1114,14 @@ func (api *BlockChainAPI) EstimateTotalFee(ctx context.Context, args Transaction
 		bNrOrHash = *blockNrOrHash
 	}
 
-	// Resolve state and header in one call, then pin bNrOrHash to the concrete block number.
-	// This avoids a redundant header lookup and prevents cross-block inconsistency when
-	// using the "latest" alias and a new block arrives during processing.
+	// Resolve state and header exactly once. Both the gas estimation and the
+	// L1/operator fee calculations below operate on this single snapshot,
+	// eliminating the redundant second lookup that DoEstimateGas would perform
+	// and guaranteeing cross-step consistency regardless of the selector type.
 	state, header, err := api.b.StateAndHeaderByNumberOrHash(ctx, bNrOrHash)
 	if err != nil {
 		return nil, err
 	}
-	bNrOrHash = rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(header.Number.Int64()))
 
 	// EstimateTotalFee is not supported for pre-Arsia blocks as L1 data fee
 	// and operator fee are Arsia+ concepts
@@ -1123,9 +1129,8 @@ func (api *BlockChainAPI) EstimateTotalFee(ctx context.Context, args Transaction
 		return nil, errors.New("eth_estimateTotalFee is not supported for pre-Arsia blocks")
 	}
 
-	// 1. Estimate L2 gas (DoEstimateGas internally resolves state+header again, but
-	// bNrOrHash is now pinned to a concrete block number so it will be consistent)
-	gasEstimate, err := DoEstimateGas(ctx, api.b, args, bNrOrHash, nil, nil, api.b.RPCGasCap())
+	// 1. Estimate L2 gas using the already-resolved state and header
+	gasEstimate, err := doEstimateGasWithState(ctx, api.b, args, state, header, nil, nil, api.b.RPCGasCap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to estimate gas: %w", err)
 	}

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -1498,7 +1498,34 @@ func TestEstimateTotalFee(t *testing.T) {
 	})
 
 	// ----------------------------------------------------------------
-	// 10. Contract creation (To = nil) → normal return
+	// 10. Block hash selector — preserved end-to-end (not converted to number)
+	// ----------------------------------------------------------------
+	t.Run("BlockHashSelector", func(t *testing.T) {
+		arsiaHeader, err := backend.HeaderByNumber(context.Background(), rpc.BlockNumber(genBlocks))
+		require.NoError(t, err)
+		require.True(t, chainCfg.IsMantleArsia(arsiaHeader.Time), "last block should be Arsia")
+
+		blockHash := arsiaHeader.Hash()
+		bNrOrHash := rpc.BlockNumberOrHashWithHash(blockHash, true)
+		args := TransactionArgs{
+			From:  &accs[0].addr,
+			To:    &accs[1].addr,
+			Value: (*hexutil.Big)(big.NewInt(1000)),
+		}
+
+		totalFee, err := api.EstimateTotalFee(context.Background(), args, &bNrOrHash)
+		require.NoError(t, err)
+		require.True(t, totalFee.ToInt().Sign() > 0, "totalFee with blockHash should be positive")
+
+		totalFeeByNum, err := api.EstimateTotalFee(context.Background(), args, nil)
+		require.NoError(t, err)
+		require.Equal(t, totalFee.ToInt().String(), totalFeeByNum.ToInt().String(),
+			"fee by hash vs latest should match for the same block")
+		t.Logf("blockHash=%s total=%s", blockHash.Hex(), totalFee.ToInt())
+	})
+
+	// ----------------------------------------------------------------
+	// 11. Contract creation (To = nil) → normal return
 	// ----------------------------------------------------------------
 	t.Run("ContractCreation", func(t *testing.T) {
 		initCode := hexutil.Bytes{0x60, 0x00, 0x60, 0x00, 0xf3} // PUSH1 0 PUSH1 0 RETURN


### PR DESCRIPTION
## Summary

- **Fix redundant state resolution in `EstimateTotalFee`**: Extract `doEstimateGasWithState` helper so `EstimateTotalFee` can pass its already-resolved state/header directly, eliminating a duplicate `StateAndHeaderByNumberOrHash` call and guaranteeing cross-step consistency regardless of block selector type (hash vs number vs "latest").
- **Fix block hash selector handling**: Remove the unnecessary conversion from block hash to block number (`bNrOrHash` pinning), which could fail or produce inconsistent results when using hash-based selectors.
- **Add test coverage**: New `BlockHashSelector` test case verifies that `EstimateTotalFee` works correctly when called with a block hash selector and produces results consistent with the latest-block path.
- **Remove unused commented-out import** in `state_processor.go`.

## Test plan

- [x] Existing `TestEstimateTotalFee` tests pass
- [x] New `BlockHashSelector` test validates hash-based block selection end-to-end
- [ ] Verify on testnet that `eth_estimateTotalFee` returns correct results with both block number and block hash parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)