### PR TITLE
Add debug logging for EstimateTotalFee breakdown

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1228,6 +1228,15 @@ func (api *BlockChainAPI) EstimateTotalFee(ctx context.Context, args Transaction
 	totalFee := new(big.Int).Add(l2GasFee, l1DataFee)
 	totalFee.Add(totalFee, operatorFee)
 
+	log.Debug("EstimateTotalFee breakdown",
+		"l2GasFee", l2GasFee,
+		"l1DataFee", l1DataFee,
+		"operatorFee", operatorFee,
+		"totalFee", totalFee,
+		"gasEstimate", uint64(gasEstimate),
+		"gasPrice", gasPrice,
+	)
+
 	return (*hexutil.Big)(totalFee), nil
 }
 


### PR DESCRIPTION
## Summary

- Add `log.Debug` output in `EstimateTotalFee` to log the fee breakdown (L2 gas fee, L1 data fee, operator fee, total fee, gas estimate, gas price)
- Helps diagnose fee estimation discrepancies in production without impacting performance (Debug level only)

## Test plan

- [ ] Verify debug logs appear when running with `--verbosity=5`
- [ ] Confirm no impact on normal operation at default log level

🤖 Generated with [Claude Code](https://claude.com/claude-code)