### PR TITLE
miner, tests/preconf: fix preconf baseFee recalculation

### DIFF
--- a/miner/preconf_checker.go
+++ b/miner/preconf_checker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -34,6 +35,7 @@ var (
 	ErrEnvBlockNumberLessThanUnsafeL2BlockNumber            = errors.New("env block number is less than unsafe l2 block number")
 	ErrEnvBlockNumberAndUnsafeL2BlockNumberDistanceTooLarge = errors.New("env block number and unsafe l2 block number distance is too large")
 	ErrPreconfNotAvailable                                  = errors.New("preconf is not available")
+	ErrPreconfBlockFull                                     = errors.New("preconf block is full")
 )
 
 const (
@@ -355,26 +357,17 @@ func (c *preconfChecker) precheck() error {
 	return nil
 }
 
-// applyTxWithResetEnv applies a transaction and resets the environment if a gas limit reached error occurs.
+// applyTxWithResetEnv applies a transaction. If the preconf block is full, it
+// returns ErrPreconfBlockFull without advancing the virtual block number. Block
+// number advances happen only in UnpausePreconf, enforcing single-block
+// preconfirmation semantics.
 func (c *preconfChecker) applyTxWithResetEnv(env *environment, tx *types.Transaction) (*types.Receipt, []byte, error) {
 	defer preconf.LogIfSlow(time.Now(), "applyTxWithResetEnv", "tx", tx.Hash().Hex(), "nonce", tx.Nonce())
 	receipt, returnData, err := c.applyTx(env, tx)
 	if err != nil {
 		if errors.Is(err, core.ErrGasLimitReached) || errors.Is(err, core.ErrBlockOversized) || errors.Is(err, core.ErrDAFootprintLimitReached) {
-			// This indicates we should reset the env's gas limit and increment header.number+1.
-			// This avoids gas limit reached errors and nonce too high errors for subsequent preconfirmation transactions.
-			// No need to worry about transactions that always fill up the block gas limit,
-			// as transactions that are too costly are filtered out when entering the transaction pool.
-			preGasLimit, txGasLimit := c.env.gasPool.Gas(), tx.Gas()
-			c.env.header.Number = new(big.Int).Add(c.env.header.Number, common.Big1)
-			c.env.gasPool = core.NewGasPool(c.env.header.GasLimit)
-			c.env.size = 0
-			// Reset DA footprint for the new block
-			if c.env.header.BlobGasUsed != nil {
-				*c.env.header.BlobGasUsed = 0
-			}
-			log.Trace("reset env for limit reached", "env.header.Number", c.env.header.Number, "env.gasPool(pre)", preGasLimit, "tx.gas", txGasLimit, "env.gasPool(now)", c.env.gasPool.Gas(), "tx", tx.Hash())
-			return c.applyTx(c.env, tx)
+			log.Debug("preconf block full, rejecting tx", "tx", tx.Hash(), "err", err)
+			return nil, nil, fmt.Errorf("%w: %w", ErrPreconfBlockFull, err)
 		}
 		return nil, nil, err
 	}
@@ -492,9 +485,23 @@ func (c *preconfChecker) UnpausePreconf(env *environment, preconfReady func()) {
 	defer c.mu.Unlock()
 	c.env = env
 	c.envUpdatedAt = time.Now()
-	// reset env
-	log.Debug("unpause preconf", "env.header.Number", env.header.Number.Int64(), "env.gasPool", c.env.gasPool, "envUpdatedAt", c.envUpdatedAt)
+
+	// Snapshot the sealed block header before mutating it. CalcBaseFee reads the
+	// parent header's Extra/GasUsed/BlobGasUsed under Arsia.
+	parentHeader := types.CopyHeader(c.env.header)
+
+	log.Debug("unpause preconf", "env.header.Number", c.env.header.Number.Int64(), "env.gasPool", c.env.gasPool, "envUpdatedAt", c.envUpdatedAt)
 	c.env.header.Number = new(big.Int).Add(c.env.header.Number, common.Big1)
+
+	chainConfig := c.env.evm.ChainConfig()
+	newBaseFee := eip1559.CalcBaseFee(chainConfig, parentHeader)
+	c.env.header.BaseFee = newBaseFee
+	log.Debug("recalculated baseFee for preconf block",
+		"parentNumber", parentHeader.Number,
+		"parentGasUsed", parentHeader.GasUsed,
+		"parentBaseFee", parentHeader.BaseFee,
+		"newBaseFee", newBaseFee)
+
 	if c.env.gasPool != nil {
 		c.env.gasPool = core.NewGasPool(c.env.header.GasLimit)
 		log.Trace("reset env", "env.header.Number", c.env.header.Number.Int64(), "env.gasPool", c.env.gasPool)
@@ -504,6 +511,9 @@ func (c *preconfChecker) UnpausePreconf(env *environment, preconfReady func()) {
 	if c.env.header.BlobGasUsed != nil {
 		*c.env.header.BlobGasUsed = 0
 	}
+
+	blockCtx := core.NewEVMBlockContext(c.env.header, c.blockchain, nil, chainConfig, c.env.state)
+	c.env.evm = vm.NewEVM(blockCtx, c.env.state, chainConfig, c.env.evm.Config)
 
 	// Load deposit txs
 	log.Trace("apply deposit txs", "deposit_txs", len(c.depositTxs))

--- a/miner/preconf_checker_test.go
+++ b/miner/preconf_checker_test.go
@@ -2,14 +2,25 @@ package miner
 
 import (
 	"context"
+	"errors"
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/preconf"
+	"github.com/holiman/uint256"
 )
 
 func TestIsSyncStatusOk(t *testing.T) {
@@ -397,5 +408,360 @@ func TestUpdateOptimismSyncStatusDelay(t *testing.T) {
 				t.Fatalf("UpdateOptimismSyncStatus() depositTxs update mismatch, expected update: %v", tt.expectDepositTxsUpdate)
 			}
 		})
+	}
+}
+
+// --- Test helpers for baseFee / block-full tests ---
+
+func newU64(v uint64) *uint64 { return &v }
+
+// newArsiaBlockchain creates a *core.BlockChain with MantleArsiaTime=0 (always active)
+// and Arsia EIP-1559 params encoded in genesis ExtraData.
+func newArsiaBlockchain(t *testing.T) *core.BlockChain {
+	t.Helper()
+	zero := uint64(0)
+	chainConfig := &params.ChainConfig{
+		ChainID:             big.NewInt(1337),
+		HomesteadBlock:      big.NewInt(0),
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		Ethash:              new(params.EthashConfig),
+		MantleArsiaTime:     &zero,
+		Optimism: &params.OptimismConfig{
+			EIP1559Elasticity:        50,
+			EIP1559Denominator:       50,
+			EIP1559DenominatorCanyon: newU64(50),
+		},
+	}
+	genesis := &core.Genesis{
+		Config:     chainConfig,
+		ExtraData:  eip1559.EncodeMinBaseFeeExtraData(50, 50, 0),
+		GasLimit:   30_000_000,
+		BaseFee:    big.NewInt(params.InitialBaseFee),
+		Difficulty: big.NewInt(1),
+	}
+	chainDB := rawdb.NewMemoryDatabase()
+	bc, err := core.NewBlockChain(chainDB, genesis, ethash.NewFaker(), nil)
+	if err != nil {
+		t.Fatalf("NewBlockChain: %v", err)
+	}
+	t.Cleanup(bc.Stop)
+	return bc
+}
+
+// newTestEnv creates a minimal *environment backed by the genesis state of bc.
+// gasPoolGas controls the available gas (pass header.GasLimit for a full pool).
+func newTestEnv(t *testing.T, bc *core.BlockChain, header *types.Header, gasPoolGas uint64) *environment {
+	t.Helper()
+	statedb, err := bc.StateAt(bc.Genesis().Root())
+	if err != nil {
+		t.Fatalf("StateAt: %v", err)
+	}
+	chainConfig := bc.Config()
+	hdr := types.CopyHeader(header)
+	blockCtx := core.NewEVMBlockContext(hdr, bc, nil, chainConfig, statedb)
+	evm := vm.NewEVM(blockCtx, statedb, chainConfig, vm.Config{})
+	gp := core.NewGasPool(gasPoolGas)
+	return &environment{
+		signer:  types.MakeSigner(chainConfig, hdr.Number, hdr.Time),
+		state:   statedb,
+		evm:     evm,
+		gasPool: gp,
+		header:  hdr,
+	}
+}
+
+// --- Block-full tests: verify virtual block advance is removed ---
+
+func TestApplyTxWithResetEnv_GasLimitReturnsBlockFull(t *testing.T) {
+	bc := newArsiaBlockchain(t)
+
+	blobGasUsed := uint64(0)
+	header := &types.Header{
+		Number:      big.NewInt(11),
+		GasLimit:    30_000_000,
+		BaseFee:     big.NewInt(params.InitialBaseFee),
+		Time:        0,
+		Extra:       eip1559.EncodeMinBaseFeeExtraData(50, 50, 0),
+		BlobGasUsed: &blobGasUsed,
+	}
+	// gasPool = 0 → any tx will trigger ErrGasLimitReached
+	env := newTestEnv(t, bc, header, 0)
+	originalNumber := new(big.Int).Set(env.header.Number)
+
+	checker := &preconfChecker{
+		blockchain:  bc,
+		env:         env,
+		minerConfig: &preconf.DefaultMinerConfig,
+	}
+
+	// Create a simple tx (gas required > 0 but pool has 0 gas)
+	key, _ := crypto.GenerateKey()
+	sender := crypto.PubkeyToAddress(key.PublicKey)
+	// Fund sender so it passes balance check and hits the gas pool check
+	env.state.AddBalance(sender, uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+	signer := types.NewEIP155Signer(bc.Config().ChainID)
+	tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		Gas:      21_000,
+		GasPrice: big.NewInt(params.InitialBaseFee),
+	}), signer, key)
+
+	_, _, err := checker.applyTxWithResetEnv(env, tx)
+
+	// Must get ErrPreconfBlockFull (wrapping ErrGasLimitReached)
+	if !errors.Is(err, ErrPreconfBlockFull) {
+		t.Fatalf("expected ErrPreconfBlockFull, got %v", err)
+	}
+	if !errors.Is(err, core.ErrGasLimitReached) {
+		t.Fatalf("expected wrapped ErrGasLimitReached, got %v", err)
+	}
+	// header.Number must NOT have advanced (no virtual block advance)
+	if env.header.Number.Cmp(originalNumber) != 0 {
+		t.Fatalf("header.Number must not advance: got %v, want %v", env.header.Number, originalNumber)
+	}
+}
+
+func TestApplyTxWithResetEnv_DASpaceReturnsBlockFull(t *testing.T) {
+	bc := newArsiaBlockchain(t)
+
+	blobGasUsed := uint64(30_000_000) // DA completely saturated
+	header := &types.Header{
+		Number:      big.NewInt(11),
+		GasLimit:    30_000_000,
+		BaseFee:     big.NewInt(params.InitialBaseFee),
+		Time:        0,
+		Extra:       eip1559.EncodeMinBaseFeeExtraData(50, 50, 0),
+		BlobGasUsed: &blobGasUsed,
+	}
+	// Gas pool is fine, but DA is exhausted
+	env := newTestEnv(t, bc, header, header.GasLimit)
+	env.daFootprintGasScalar = 1 // activate DA check (scalar=0 disables it)
+	originalNumber := new(big.Int).Set(env.header.Number)
+
+	checker := &preconfChecker{
+		blockchain:  bc,
+		env:         env,
+		minerConfig: &preconf.DefaultMinerConfig,
+	}
+
+	key, _ := crypto.GenerateKey()
+	signer := types.NewEIP155Signer(bc.Config().ChainID)
+	tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+		Nonce:    0,
+		Gas:      21_000,
+		GasPrice: big.NewInt(params.InitialBaseFee),
+	}), signer, key)
+
+	_, _, err := checker.applyTxWithResetEnv(env, tx)
+
+	// Must get ErrPreconfBlockFull (wrapping ErrDAFootprintLimitReached)
+	if !errors.Is(err, ErrPreconfBlockFull) {
+		t.Fatalf("expected ErrPreconfBlockFull, got %v", err)
+	}
+	if !errors.Is(err, core.ErrDAFootprintLimitReached) {
+		t.Fatalf("expected wrapped ErrDAFootprintLimitReached, got %v", err)
+	}
+	// header.Number must NOT have advanced
+	if env.header.Number.Cmp(originalNumber) != 0 {
+		t.Fatalf("header.Number must not advance: got %v, want %v", env.header.Number, originalNumber)
+	}
+}
+
+// --- UnpausePreconf baseFee recalculation test ---
+
+func TestUnpausePreconf_BaseFeeRecalculated(t *testing.T) {
+	bc := newArsiaBlockchain(t)
+	chainConfig := bc.Config()
+
+	gasLimit := uint64(30_000_000)
+	daUsed := gasLimit // BlobGasUsed == GasLimit → parentGasMetered = max(GasUsed, BlobGasUsed)
+	arsiaExtra := eip1559.EncodeMinBaseFeeExtraData(50, 50, 0)
+
+	sealedHeader := &types.Header{
+		Number:      big.NewInt(10),
+		GasLimit:    gasLimit,
+		GasUsed:     gasLimit, // 100% utilisation → baseFee must increase
+		BlobGasUsed: &daUsed,
+		BaseFee:     big.NewInt(params.InitialBaseFee),
+		Time:        0,
+		Extra:       arsiaExtra,
+		Difficulty:  big.NewInt(1),
+	}
+
+	// Ground truth: what CalcBaseFee computes for the next block
+	expectedBaseFee := eip1559.CalcBaseFee(chainConfig, sealedHeader)
+	if expectedBaseFee.Cmp(sealedHeader.BaseFee) == 0 {
+		t.Fatal("test setup error: baseFee unchanged — gas params may be wrong")
+	}
+
+	// Build environment from the sealed header
+	env := newTestEnv(t, bc, sealedHeader, gasLimit)
+	// BlobGasUsed must match for CalcBaseFee to read the correct parentGasMetered
+	*env.header.BlobGasUsed = daUsed
+	env.header.GasUsed = gasLimit
+
+	// Set up the unsealed preconf txs channel (empty, no overflow)
+	unSealedCh := make(chan []*types.Transaction, 1)
+	unSealedCh <- []*types.Transaction{}
+
+	checker := &preconfChecker{
+		blockchain:           bc,
+		depositTxs:           nil,
+		unSealedPreconfTxsCh: unSealedCh,
+		minerConfig:          &preconf.DefaultMinerConfig,
+	}
+
+	readyCalled := false
+	// UnpausePreconf defers mu.Unlock(), so we must hold the lock
+	checker.mu.Lock()
+	checker.UnpausePreconf(env, func() { readyCalled = true })
+
+	// preconfReady callback was called
+	if !readyCalled {
+		t.Error("preconfReady was not called")
+	}
+
+	// Block number advanced by 1
+	wantNumber := new(big.Int).Add(sealedHeader.Number, common.Big1)
+	if checker.env.header.Number.Cmp(wantNumber) != 0 {
+		t.Errorf("header.Number: got %v, want %v", checker.env.header.Number, wantNumber)
+	}
+
+	// BaseFee on the header is recalculated (not stale)
+	if checker.env.header.BaseFee.Cmp(expectedBaseFee) != 0 {
+		t.Errorf("header.BaseFee: got %v, want %v",
+			checker.env.header.BaseFee, expectedBaseFee)
+	}
+
+	// EVM BlockContext.BaseFee is also updated (EVM was rebuilt)
+	if checker.env.evm.Context.BaseFee.Cmp(expectedBaseFee) != 0 {
+		t.Errorf("evm.Context.BaseFee: got %v, want %v",
+			checker.env.evm.Context.BaseFee, expectedBaseFee)
+	}
+
+	// BlobGasUsed reset to 0 for new block
+	if *checker.env.header.BlobGasUsed != 0 {
+		t.Errorf("BlobGasUsed not reset: got %d", *checker.env.header.BlobGasUsed)
+	}
+
+	// Gas pool reset to full
+	if checker.env.gasPool.Gas() != gasLimit {
+		t.Errorf("gasPool.Gas(): got %d, want %d", checker.env.gasPool.Gas(), gasLimit)
+	}
+}
+
+// --- C1 supplement: non gas/DA errors pass through without wrapping ---
+
+func TestApplyTxWithResetEnv_OtherErrorsPassThrough(t *testing.T) {
+	bc := newArsiaBlockchain(t)
+
+	blobGasUsed := uint64(0)
+	header := &types.Header{
+		Number:      big.NewInt(11),
+		GasLimit:    30_000_000,
+		BaseFee:     big.NewInt(params.InitialBaseFee),
+		Time:        0,
+		Extra:       eip1559.EncodeMinBaseFeeExtraData(50, 50, 0),
+		BlobGasUsed: &blobGasUsed,
+	}
+	env := newTestEnv(t, bc, header, header.GasLimit) // gas pool is full
+
+	checker := &preconfChecker{
+		blockchain:  bc,
+		env:         env,
+		minerConfig: &preconf.DefaultMinerConfig,
+	}
+
+	// Create a tx with nonce=999 (way ahead of actual nonce 0) → triggers nonce-too-high error
+	key, _ := crypto.GenerateKey()
+	sender := crypto.PubkeyToAddress(key.PublicKey)
+	env.state.AddBalance(sender, uint256.NewInt(1e18), tracing.BalanceChangeUnspecified)
+	signer := types.NewEIP155Signer(bc.Config().ChainID)
+	tx, _ := types.SignTx(types.NewTx(&types.LegacyTx{
+		Nonce:    999, // nonce too high
+		Gas:      21_000,
+		GasPrice: big.NewInt(params.InitialBaseFee),
+	}), signer, key)
+
+	_, _, err := checker.applyTxWithResetEnv(env, tx)
+
+	// Must NOT be ErrPreconfBlockFull — should be original error
+	if err == nil {
+		t.Fatal("expected error for nonce-too-high tx, got nil")
+	}
+	if errors.Is(err, ErrPreconfBlockFull) {
+		t.Fatalf("non gas/DA error should not be wrapped as ErrPreconfBlockFull, got %v", err)
+	}
+}
+
+// --- C2 supplement: baseFee decreases on low utilisation ---
+
+func TestUnpausePreconf_BaseFeeDecreasesOnLowUtil(t *testing.T) {
+	bc := newArsiaBlockchain(t)
+	chainConfig := bc.Config()
+
+	gasLimit := uint64(30_000_000)
+	daUsed := uint64(0) // empty block
+	arsiaExtra := eip1559.EncodeMinBaseFeeExtraData(50, 50, 0)
+
+	// Start with a high baseFee so there's room to decrease
+	highBaseFee := new(big.Int).Mul(big.NewInt(params.InitialBaseFee), big.NewInt(10))
+
+	sealedHeader := &types.Header{
+		Number:      big.NewInt(10),
+		GasLimit:    gasLimit,
+		GasUsed:     0, // 0% utilisation → baseFee must decrease
+		BlobGasUsed: &daUsed,
+		BaseFee:     highBaseFee,
+		Time:        0,
+		Extra:       arsiaExtra,
+		Difficulty:  big.NewInt(1),
+	}
+
+	expectedBaseFee := eip1559.CalcBaseFee(chainConfig, sealedHeader)
+	if expectedBaseFee.Cmp(sealedHeader.BaseFee) >= 0 {
+		t.Fatal("test setup error: baseFee did not decrease — expected lower baseFee for empty block")
+	}
+
+	env := newTestEnv(t, bc, sealedHeader, gasLimit)
+	*env.header.BlobGasUsed = daUsed
+	env.header.GasUsed = 0
+
+	unSealedCh := make(chan []*types.Transaction, 1)
+	unSealedCh <- []*types.Transaction{}
+
+	checker := &preconfChecker{
+		blockchain:           bc,
+		depositTxs:           nil,
+		unSealedPreconfTxsCh: unSealedCh,
+		minerConfig:          &preconf.DefaultMinerConfig,
+	}
+
+	checker.mu.Lock()
+	checker.UnpausePreconf(env, func() {})
+
+	// BaseFee must have decreased
+	if checker.env.header.BaseFee.Cmp(highBaseFee) >= 0 {
+		t.Errorf("header.BaseFee should decrease: got %v, parent was %v",
+			checker.env.header.BaseFee, highBaseFee)
+	}
+	if checker.env.header.BaseFee.Cmp(expectedBaseFee) != 0 {
+		t.Errorf("header.BaseFee: got %v, want %v",
+			checker.env.header.BaseFee, expectedBaseFee)
+	}
+
+	// EVM must also reflect the decreased baseFee
+	if checker.env.evm.Context.BaseFee.Cmp(expectedBaseFee) != 0 {
+		t.Errorf("evm.Context.BaseFee: got %v, want %v",
+			checker.env.evm.Context.BaseFee, expectedBaseFee)
 	}
 }

--- a/tests/preconf/basefee/basefee.go
+++ b/tests/preconf/basefee/basefee.go
@@ -1,0 +1,183 @@
+// Package basefee verifies that preconf receipt data is consistent with on-chain
+// receipts after baseFee changes caused by consecutive full blocks.
+package basefee
+
+import (
+	"context"
+	"log"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/tests/preconf/config"
+)
+
+const (
+	numBlocks      = 20
+	blockWait      = 3 * time.Second
+	transferAmount = 1_000_000_000 // 1 gwei — small amount, we only care about baseFee
+)
+
+// BaseFeeConsistencyTest sends preconf txs across multiple blocks and verifies
+// that the PredictedL2BlockNumber in the preconf response matches the actual
+// on-chain block, and that the on-chain receipt's EffectiveGasPrice is consistent
+// with the baseFee progression.
+func BaseFeeConsistencyTest() {
+	log.Printf("=== Start baseFee consistency test (%d blocks) ===", numBlocks)
+
+	ctx := context.Background()
+	client, err := ethclient.Dial(config.L2RpcEndpoint)
+	if err != nil {
+		log.Fatalf("[basefee] failed to connect to L2 RPC: %v", err)
+	}
+	defer client.Close()
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		log.Fatalf("[basefee] failed to get chain ID: %v", err)
+	}
+
+	auth, err := bind.NewKeyedTransactorWithChainID(config.FunderKey, chainID)
+	if err != nil {
+		log.Fatalf("[basefee] failed to create signer: %v", err)
+	}
+
+	// Record starting block
+	startHeader, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		log.Fatalf("[basefee] failed to get start header: %v", err)
+	}
+	startBlock := startHeader.Number.Uint64()
+	log.Printf("[basefee] starting at block %d, baseFee=%s", startBlock, startHeader.BaseFee)
+
+	type txRecord struct {
+		tx                     *types.Transaction
+		predictedL2BlockNumber uint64
+		baseFeeAtSubmission    *big.Int
+	}
+
+	var records []txRecord
+	prevBaseFee := new(big.Int).Set(startHeader.BaseFee)
+
+	// Self-managed nonce to avoid "already known" errors
+	nonce, err := client.PendingNonceAt(ctx, auth.From)
+	if err != nil {
+		log.Fatalf("[basefee] failed to get initial nonce: %v", err)
+	}
+
+	for i := 0; i < numBlocks; i++ {
+		// Get current head for baseFee
+		head, err := client.HeaderByNumber(ctx, nil)
+		if err != nil {
+			log.Fatalf("[basefee] block %d: failed to get header: %v", i, err)
+		}
+		currentBaseFee := head.BaseFee
+
+		// Log baseFee change
+		if i > 0 {
+			diff := new(big.Int).Sub(currentBaseFee, prevBaseFee)
+			log.Printf("[basefee] block %d: baseFee=%s (Δ=%s)", i, currentBaseFee, diff)
+		}
+
+		gasTipCap := big.NewInt(0)
+		gasFeeCap := new(big.Int).Add(
+			gasTipCap,
+			new(big.Int).Mul(currentBaseFee, big.NewInt(2)),
+		)
+
+		to := common.HexToAddress(config.ToAddressHex)
+		tx := types.NewTx(&types.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     nonce,
+			To:        &to,
+			GasTipCap: gasTipCap,
+			GasFeeCap: gasFeeCap,
+			Gas:       21_000,
+			Value:     big.NewInt(transferAmount),
+		})
+
+		signedTx, err := auth.Signer(auth.From, tx)
+		if err != nil {
+			log.Fatalf("[basefee] block %d: failed to sign tx: %v", i, err)
+		}
+
+		var result core.NewPreconfTxEvent
+		if err := client.SendTransactionWithPreconf(ctx, signedTx, &result); err != nil {
+			log.Fatalf("[basefee] block %d: failed to send preconf tx: %v", i, err)
+		}
+
+		if result.Status != core.PreconfStatusSuccess {
+			log.Fatalf("[basefee] block %d: preconf failed: status=%s reason=%s",
+				i, result.Status, result.Reason)
+		}
+
+		records = append(records, txRecord{
+			tx:                     signedTx,
+			predictedL2BlockNumber: uint64(result.PredictedL2BlockNumber),
+			baseFeeAtSubmission:    new(big.Int).Set(currentBaseFee),
+		})
+
+		nonce++ // self-managed nonce
+		prevBaseFee = new(big.Int).Set(currentBaseFee)
+		time.Sleep(blockWait)
+	}
+
+	// Verify: each preconf tx landed on-chain and the block's baseFee is consistent
+	log.Printf("[basefee] verifying %d txs on-chain...", len(records))
+	mismatchCount := 0
+
+	for i, rec := range records {
+		waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		receipt, err := bind.WaitMined(waitCtx, client, rec.tx)
+		cancel()
+		if err != nil {
+			log.Fatalf("[basefee] tx %d: failed to get receipt: %v", i, err)
+		}
+
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			log.Fatalf("[basefee] tx %d: tx reverted on-chain", i)
+		}
+
+		// Get the block this tx actually landed in
+		block, err := client.BlockByNumber(ctx, new(big.Int).SetUint64(receipt.BlockNumber.Uint64()))
+		if err != nil {
+			log.Fatalf("[basefee] tx %d: failed to get block %d: %v", i, receipt.BlockNumber.Uint64(), err)
+		}
+		actualBaseFee := block.BaseFee()
+
+		// Compare predicted block number vs actual
+		if rec.predictedL2BlockNumber != receipt.BlockNumber.Uint64() {
+			log.Printf("[basefee] tx %d: block mismatch: predicted=%d actual=%d (tolerable ±1)",
+				i, rec.predictedL2BlockNumber, receipt.BlockNumber.Uint64())
+		}
+
+		// The baseFee at submission should be close to the block's actual baseFee
+		// With the fix, they should be equal (same CalcBaseFee input).
+		// Without the fix, the preconf baseFee lags behind.
+		if actualBaseFee.Cmp(rec.baseFeeAtSubmission) != 0 {
+			mismatchCount++
+			log.Printf("[basefee] tx %d: baseFee mismatch: atSubmission=%s onChain=%s blockNum=%d",
+				i, rec.baseFeeAtSubmission, actualBaseFee, receipt.BlockNumber.Uint64())
+		}
+	}
+
+	if mismatchCount > 0 {
+		log.Printf("[basefee] ⚠ %d/%d txs had baseFee mismatch (may be due to block boundaries)", mismatchCount, len(records))
+	} else {
+		log.Printf("[basefee] ✅ all %d txs: baseFee at submission matches on-chain block baseFee", len(records))
+	}
+
+	// Log the baseFee curve
+	endHeader, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		log.Fatalf("[basefee] failed to get end header: %v", err)
+	}
+	log.Printf("[basefee] baseFee curve: start=%s end=%s (blocks %d→%d)",
+		startHeader.BaseFee, endHeader.BaseFee, startBlock, endHeader.Number.Uint64())
+
+	log.Printf("=== baseFee consistency test completed ===")
+}

--- a/tests/preconf/basefee_stress/stress.go
+++ b/tests/preconf/basefee_stress/stress.go
@@ -1,0 +1,185 @@
+// Package basefee_stress is an optional stress test that sends high-TPS preconf
+// traffic for many consecutive blocks, verifying baseFee growth follows the
+// EIP-1559 formula and no panics/deadlocks occur.
+package basefee_stress
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/tests/preconf/config"
+)
+
+const (
+	stressBlocks   = 50
+	concurrency    = 10
+	txsPerRound    = 20
+	roundSleep     = 2 * time.Second
+	transferAmount = 1_000_000_000 // 1 gwei
+)
+
+// StressTest sends high-TPS preconf txs for stressBlocks consecutive blocks
+// and verifies baseFee growth.
+func StressTest() {
+	log.Printf("=== Start baseFee stress test (%d blocks, concurrency=%d) ===", stressBlocks, concurrency)
+
+	ctx := context.Background()
+	client, err := ethclient.Dial(config.L2RpcEndpoint)
+	if err != nil {
+		log.Fatalf("[basefee_stress] failed to connect: %v", err)
+	}
+	defer client.Close()
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		log.Fatalf("[basefee_stress] failed to get chain ID: %v", err)
+	}
+
+	auth, err := bind.NewKeyedTransactorWithChainID(config.FunderKey, chainID)
+	if err != nil {
+		log.Fatalf("[basefee_stress] failed to create signer: %v", err)
+	}
+
+	to := common.HexToAddress(config.ToAddressHex)
+
+	// Record baseFee at start
+	startHeader, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		log.Fatalf("[basefee_stress] failed to get start header: %v", err)
+	}
+
+	type blockRecord struct {
+		number  uint64
+		baseFee *big.Int
+		gasUsed uint64
+	}
+	var baseFeeHistory []blockRecord
+	baseFeeHistory = append(baseFeeHistory, blockRecord{
+		number:  startHeader.Number.Uint64(),
+		baseFee: startHeader.BaseFee,
+	})
+
+	var totalSuccess atomic.Int64
+	var totalFailed atomic.Int64
+	var mu sync.Mutex
+	var nonceCounter uint64
+
+	// Get initial nonce
+	nonceCounter, err = client.PendingNonceAt(ctx, auth.From)
+	if err != nil {
+		log.Fatalf("[basefee_stress] failed to get nonce: %v", err)
+	}
+
+	for round := range stressBlocks {
+		head, err := client.HeaderByNumber(ctx, nil)
+		if err != nil {
+			log.Fatalf("[basefee_stress] round %d: failed to get header: %v", round, err)
+		}
+
+		gasFeeCap := new(big.Int).Mul(head.BaseFee, big.NewInt(2))
+
+		// Send a batch concurrently
+		var wg sync.WaitGroup
+		for j := range txsPerRound {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+
+				mu.Lock()
+				nonce := nonceCounter
+				nonceCounter++
+				mu.Unlock()
+
+				tx := types.NewTx(&types.DynamicFeeTx{
+					ChainID:   chainID,
+					Nonce:     nonce,
+					To:        &to,
+					GasTipCap: big.NewInt(0),
+					GasFeeCap: gasFeeCap,
+					Gas:       21_000,
+					Value:     big.NewInt(transferAmount),
+				})
+
+				signedTx, err := auth.Signer(auth.From, tx)
+				if err != nil {
+					log.Printf("[basefee_stress] round %d tx %d: sign error: %v", round, idx, err)
+					totalFailed.Add(1)
+					return
+				}
+
+				var result core.NewPreconfTxEvent
+				if err := client.SendTransactionWithPreconf(ctx, signedTx, &result); err != nil {
+					totalFailed.Add(1)
+					return
+				}
+
+				if result.Status == core.PreconfStatusSuccess {
+					totalSuccess.Add(1)
+				} else {
+					totalFailed.Add(1)
+				}
+			}(j)
+		}
+		wg.Wait()
+
+		// Record baseFee after this round
+		postHead, err := client.HeaderByNumber(ctx, nil)
+		if err == nil && postHead.Number.Uint64() > baseFeeHistory[len(baseFeeHistory)-1].number {
+			// Capture intermediate blocks we may have missed
+			for n := baseFeeHistory[len(baseFeeHistory)-1].number + 1; n <= postHead.Number.Uint64(); n++ {
+				block, err := client.BlockByNumber(ctx, new(big.Int).SetUint64(n))
+				if err != nil {
+					continue
+				}
+				baseFeeHistory = append(baseFeeHistory, blockRecord{
+					number:  n,
+					baseFee: block.BaseFee(),
+					gasUsed: block.GasUsed(),
+				})
+			}
+		}
+
+		if round%10 == 0 {
+			log.Printf("[basefee_stress] round %d/%d: success=%d failed=%d baseFee=%s",
+				round, stressBlocks, totalSuccess.Load(), totalFailed.Load(), head.BaseFee)
+		}
+
+		time.Sleep(roundSleep)
+	}
+
+	// Print baseFee curve summary
+	log.Printf("[basefee_stress] baseFee curve (%d data points):", len(baseFeeHistory))
+	for i, rec := range baseFeeHistory {
+		fillPct := ""
+		if i > 0 && rec.gasUsed > 0 {
+			// Approximate fill ratio (may not have GasLimit from header)
+			fillPct = fmt.Sprintf(" gasUsed=%d", rec.gasUsed)
+		}
+		if i < 5 || i >= len(baseFeeHistory)-5 || i%10 == 0 {
+			log.Printf("  block %d: baseFee=%s%s", rec.number, rec.baseFee, fillPct)
+		}
+	}
+
+	// Verify baseFee increased (assuming blocks were full)
+	first := baseFeeHistory[0].baseFee
+	last := baseFeeHistory[len(baseFeeHistory)-1].baseFee
+	if last.Cmp(first) <= 0 {
+		log.Printf("[basefee_stress] ⚠ baseFee did not increase: start=%s end=%s — blocks may not have been full", first, last)
+	} else {
+		ratio := new(big.Float).Quo(new(big.Float).SetInt(last), new(big.Float).SetInt(first))
+		log.Printf("[basefee_stress] ✅ baseFee increased: start=%s end=%s ratio=%s", first, last, ratio.Text('f', 4))
+	}
+
+	log.Printf("[basefee_stress] totals: success=%d failed=%d", totalSuccess.Load(), totalFailed.Load())
+	log.Printf("=== baseFee stress test completed ===")
+}

--- a/tests/preconf/blockfull/blockfull.go
+++ b/tests/preconf/blockfull/blockfull.go
@@ -1,0 +1,182 @@
+// Package blockfull verifies preconf block-full behaviour:
+//   - Preconf returns failure when the block is full.
+//   - Preconf txs that succeeded are 100% landed on-chain.
+//   - After the next block cycle, a previously rejected tx can be resubmitted.
+package blockfull
+
+import (
+	"context"
+	"log"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/tests/preconf/config"
+)
+
+// BlockFullTest sends preconf txs until the block is full, then verifies:
+// 1. Successful preconf txs are on-chain.
+// 2. A failed tx can be retried in the next block.
+func BlockFullTest() {
+	log.Printf("=== Start block-full test ===")
+
+	ctx := context.Background()
+	client, err := ethclient.Dial(config.L2RpcEndpoint)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to connect to L2 RPC: %v", err)
+	}
+	defer client.Close()
+
+	chainID, err := client.ChainID(ctx)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to get chain ID: %v", err)
+	}
+
+	auth, err := bind.NewKeyedTransactorWithChainID(config.FunderKey, chainID)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to create signer: %v", err)
+	}
+
+	to := common.HexToAddress(config.ToAddressHex)
+	amount := big.NewInt(1_000_000_000) // 1 gwei
+
+	// Phase 1: Send preconf txs until one fails
+	var succeeded []*types.Transaction
+	var gotBlockFull bool
+
+	// Query actual block gas limit to size txs correctly
+	head, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to get header: %v", err)
+	}
+	blockGasLimit := head.GasLimit
+	// Use ~80% of block gas limit per tx so 2 txs fill a block
+	txGas := blockGasLimit * 80 / 100
+	log.Printf("[blockfull] block gasLimit=%d, using txGas=%d per tx", blockGasLimit, txGas)
+
+	// Self-managed nonce
+	nonce, err := client.PendingNonceAt(ctx, auth.From)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to get nonce: %v", err)
+	}
+
+	for i := 0; i < 500; i++ {
+		head, err := client.HeaderByNumber(ctx, nil)
+		if err != nil {
+			log.Fatalf("[blockfull] failed to get header: %v", err)
+		}
+
+		gasFeeCap := new(big.Int).Mul(head.BaseFee, big.NewInt(2))
+		tx := types.NewTx(&types.DynamicFeeTx{
+			ChainID:   chainID,
+			Nonce:     nonce,
+			To:        &to,
+			GasTipCap: big.NewInt(0),
+			GasFeeCap: gasFeeCap,
+			Gas:       txGas,
+			Value:     amount,
+		})
+
+		signedTx, err := auth.Signer(auth.From, tx)
+		if err != nil {
+			log.Fatalf("[blockfull] failed to sign tx: %v", err)
+		}
+
+		var result core.NewPreconfTxEvent
+		if err := client.SendTransactionWithPreconf(ctx, signedTx, &result); err != nil {
+			// RPC-level error (e.g., intrinsic gas too low) — not block full
+			log.Printf("[blockfull] tx %d: RPC error: %v", i, err)
+			continue
+		}
+
+		if result.Status == core.PreconfStatusFailed {
+			log.Printf("[blockfull] tx %d: preconf failed (reason=%s) — block may be full", i, result.Reason)
+			gotBlockFull = true
+			break
+		}
+
+		succeeded = append(succeeded, signedTx)
+		nonce++
+		log.Printf("[blockfull] tx %d: preconf succeeded (predicted block=%d)", i, result.PredictedL2BlockNumber)
+	}
+
+	if !gotBlockFull {
+		log.Printf("[blockfull] ⚠ sent 500 txs without hitting block full — test inconclusive (block gas limit may be very large)")
+		log.Printf("=== block-full test completed (inconclusive) ===")
+		return
+	}
+
+	log.Printf("[blockfull] %d txs succeeded before block full", len(succeeded))
+
+	// Phase 2: Verify all succeeded txs are on-chain
+	log.Printf("[blockfull] verifying %d succeeded txs on-chain...", len(succeeded))
+	for i, tx := range succeeded {
+		waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		receipt, err := bind.WaitMined(waitCtx, client, tx)
+		cancel()
+		if err != nil {
+			log.Fatalf("[blockfull] tx %d: failed to get receipt: %v", i, err)
+		}
+		if receipt.Status != types.ReceiptStatusSuccessful {
+			log.Fatalf("[blockfull] tx %d: preconf succeeded but on-chain reverted!", i)
+		}
+	}
+	log.Printf("[blockfull] ✅ all %d succeeded txs confirmed on-chain", len(succeeded))
+
+	// Phase 3: Wait for next block cycle, then retry a new tx
+	log.Printf("[blockfull] waiting for next block cycle (3s)...")
+	time.Sleep(3 * time.Second)
+
+	head, err = client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to get header after wait: %v", err)
+	}
+
+	// Re-fetch nonce (previous succeeded txs advanced it)
+	retryNonce, err := client.PendingNonceAt(ctx, auth.From)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to get retry nonce: %v", err)
+	}
+
+	retryFeeCap := new(big.Int).Mul(head.BaseFee, big.NewInt(2))
+	retryTx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     retryNonce,
+		To:        &to,
+		GasTipCap: big.NewInt(0),
+		GasFeeCap: retryFeeCap,
+		Gas:       21_000, // small gas this time
+		Value:     amount,
+	})
+
+	signedRetry, err := auth.Signer(auth.From, retryTx)
+	if err != nil {
+		log.Fatalf("[blockfull] failed to sign retry tx: %v", err)
+	}
+
+	var retryResult core.NewPreconfTxEvent
+	if err := client.SendTransactionWithPreconf(ctx, signedRetry, &retryResult); err != nil {
+		log.Fatalf("[blockfull] retry tx RPC error: %v", err)
+	}
+
+	if retryResult.Status != core.PreconfStatusSuccess {
+		log.Fatalf("[blockfull] retry tx failed: status=%s reason=%s", retryResult.Status, retryResult.Reason)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	receipt, err := bind.WaitMined(waitCtx, client, signedRetry)
+	cancel()
+	if err != nil {
+		log.Fatalf("[blockfull] retry tx: failed to get receipt: %v", err)
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		log.Fatalf("[blockfull] retry tx: on-chain reverted!")
+	}
+
+	log.Printf("[blockfull] ✅ retry tx succeeded in block %d", receipt.BlockNumber.Uint64())
+	log.Printf("=== block-full test completed ===")
+}

--- a/tests/preconf/main.go
+++ b/tests/preconf/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"github.com/ethereum/go-ethereum/tests/preconf/basefee"
+	basefee_stress "github.com/ethereum/go-ethereum/tests/preconf/basefee_stress"
+	"github.com/ethereum/go-ethereum/tests/preconf/blockfull"
 	"github.com/ethereum/go-ethereum/tests/preconf/check"
 	frontrunning "github.com/ethereum/go-ethereum/tests/preconf/front_running"
 	"github.com/ethereum/go-ethereum/tests/preconf/sort"
@@ -17,5 +20,11 @@ func main() {
 	frontrunning.TransferTest()
 	sort.SortTest()
 	frontrunning.ERC20Test()
+
+	// baseFee consistency & block-full tests (added for preconf baseFee recalc PR)
+	basefee.BaseFeeConsistencyTest()
+	blockfull.BlockFullTest()
+	basefee_stress.StressTest()
+
 	// reorg.L1ReorgDetection(common.HexToHash("0xe3f60268eb85440e5b2212cb748b3ea3df4cac7973a846ea16f7fa85c68a5eda"))
 }


### PR DESCRIPTION
## Summary
- recalculate preconf baseFee from the sealed parent when preconf resumes
- keep gas-pool, blob-gas, and EVM context aligned with the advanced virtual block
- treat gas/block-size/DA-full errors as terminal for the current preconf block instead of advancing virtual blocks
- add unit coverage and preconf scenario programs for baseFee, block-full, and baseFee stress cases

## Validation
- `gofmt -l miner/preconf_checker.go miner/preconf_checker_test.go tests/preconf/main.go tests/preconf/basefee/basefee.go tests/preconf/basefee_stress/stress.go tests/preconf/blockfull/blockfull.go`
- `go test -count=1 ./miner -run 'TestApplyTxWithResetEnv|TestUnpausePreconf'`\n- `go test -count=1 ./tests/preconf/...`\n- `go test -count=1 ./miner`\n\nNote: the full `go run ./tests/preconf/` entrypoint still depends on the existing TestERC20/TestPay deployment setup; the new focused preconf scenarios were checked separately on the local devnet.