### PR TITLE
miner: set preconf admission env timestamp to the next block's time

### DIFF
--- a/miner/preconf_checker.go
+++ b/miner/preconf_checker.go
@@ -480,6 +480,12 @@ func (c *preconfChecker) PausePreconf() chan<- []*types.Transaction {
 	return c.unSealedPreconfTxsCh
 }
 
+// preconfL2BlockTime is the fixed Mantle L2 block interval in seconds. The admission
+// env is block N+1, so its timestamp = sealed N's time + this interval. The value is not
+// in params.ChainConfig (it lives in the op-node rollup config), so it is hardcoded here;
+// if the L2 block time ever changes this must be updated.
+const preconfL2BlockTime = 2
+
 // nextBlockEnv constructs the preconf admission environment for the block after env,
 // reusing env's post-execution state. It cannot use makeEnv (which derives from an
 // already-committed parent; block N is not committed at this point), so it whitelists
@@ -496,6 +502,13 @@ func (env *environment) nextBlockEnv(chain core.ChainContext) *environment {
 	// from the unmutated sealed header before zeroing GasUsed on the child.
 	header.BaseFee = eip1559.CalcBaseFee(chainConfig, env.header)
 	header.Number = new(big.Int).Add(env.header.Number, common.Big1)
+	// The admission env represents block N+1; its timestamp = sealed N's time + the fixed
+	// L2 block interval. Without this, CopyHeader carries N's time, so admission's TIMESTAMP
+	// is one block (2s) early relative to where the tx actually lands. Set it before
+	// MakeSigner below so the rebuilt signer is fork-correct for the child's time. Time is the
+	// only header field both obtainable and correct here; ParentHash and the roots can't be,
+	// since block N is not sealed yet when this env is built.
+	header.Time = env.header.Time + preconfL2BlockTime
 	header.GasUsed = 0 // P2: reset the CumulativeGasUsed accumulator carried in the header
 	if header.BlobGasUsed != nil {
 		zero := uint64(0)

--- a/miner/preconf_checker_test.go
+++ b/miner/preconf_checker_test.go
@@ -1193,26 +1193,34 @@ func TestNextBlockEnv_DoesNotMutateReceiver(t *testing.T) {
 	env := newTestEnv(t, bc, sizeTestHeader(), 30_000_000)
 	env.header.GasUsed = 5_000_000
 	env.size = 6_000_000
+	env.header.Time = 1000
 	*env.header.BlobGasUsed = 700_000
 
 	wantNumber := new(big.Int).Set(env.header.Number)
 	wantGasUsed := env.header.GasUsed
 	wantSize := env.size
+	wantTime := env.header.Time
 	wantBlobGasUsed := *env.header.BlobGasUsed
 
 	next := env.nextBlockEnv(bc)
 
-	// Child is the next block: number advanced, gas accumulator zeroed.
+	// Child is the next block: number advanced, gas accumulator zeroed, time +interval.
 	if got, want := next.header.Number, new(big.Int).Add(wantNumber, common.Big1); got.Cmp(want) != 0 {
 		t.Fatalf("child header.Number=%s, want %s", got, want)
 	}
 	if next.header.GasUsed != 0 {
 		t.Fatalf("child header.GasUsed=%d, want 0", next.header.GasUsed)
 	}
+	if got, want := next.header.Time, wantTime+preconfL2BlockTime; got != want {
+		t.Fatalf("child header.Time=%d, want %d (parent+%d)", got, want, preconfL2BlockTime)
+	}
 
 	// Receiver must be untouched.
 	if env.header.Number.Cmp(wantNumber) != 0 {
 		t.Fatalf("nextBlockEnv mutated receiver header.Number: got %s want %s", env.header.Number, wantNumber)
+	}
+	if env.header.Time != wantTime {
+		t.Fatalf("nextBlockEnv mutated receiver header.Time: got %d want %d", env.header.Time, wantTime)
 	}
 	if env.header.GasUsed != wantGasUsed {
 		t.Fatalf("nextBlockEnv mutated receiver header.GasUsed: got %d want %d", env.header.GasUsed, wantGasUsed)
@@ -1222,6 +1230,30 @@ func TestNextBlockEnv_DoesNotMutateReceiver(t *testing.T) {
 	}
 	if *env.header.BlobGasUsed != wantBlobGasUsed {
 		t.Fatalf("nextBlockEnv mutated receiver header.BlobGasUsed: got %d want %d (in-place *ptr mutation leaks into the sealed env)", *env.header.BlobGasUsed, wantBlobGasUsed)
+	}
+}
+
+// TestNextBlockEnv_TimeAdvancesByBlockInterval locks the admission-env timestamp: the env
+// represents block N+1, so its timestamp must be sealed N's time + the fixed L2 block interval.
+// Otherwise CopyHeader carries N's time verbatim, making admission's TIMESTAMP one block (2s)
+// early relative to where the tx actually lands. Behaviour-level: also asserts the EVM block
+// context the tx simulates against sees the advanced time (TIMESTAMP opcode reads
+// evm.Context.Time). Regresses to FAIL if the +interval is dropped.
+func TestNextBlockEnv_TimeAdvancesByBlockInterval(t *testing.T) {
+	bc := newArsiaBlockchain(t)
+	env := newTestEnv(t, bc, sizeTestHeader(), 30_000_000)
+	env.header.Time = 1000 // arbitrary sealed-N timestamp
+
+	next := env.nextBlockEnv(bc)
+
+	want := uint64(1000 + preconfL2BlockTime)
+	if got := next.header.Time; got != want {
+		t.Fatalf("admission env header.Time=%d, want %d (sealed N.Time + %d)", got, want, preconfL2BlockTime)
+	}
+	// The EVM block context the admission simulates against must see the advanced time,
+	// otherwise the TIMESTAMP opcode would return N's time instead of N+1's.
+	if got := next.evm.Context.Time; got != want {
+		t.Fatalf("EVM block context Time=%d, want %d (TIMESTAMP opcode would read the wrong block's time)", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

The preconf admission environment (`nextBlockEnv`) represents block N+1, but it carried the sealed block N's timestamp verbatim through `CopyHeader`. So the admission-time EVM block context — the `TIMESTAMP` opcode and time-based fork gating — ran one L2 block (2s) behind the block the transaction actually lands in, and time-sensitive contracts could simulate against the wrong timestamp.

## Fix

Set the admission header's time to the parent's time plus the fixed L2 block interval (2s), so admission simulates against the same timestamp the tx will see when packed.

`Time` is the only header field that is both obtainable and correct when the admission env is built. `ParentHash` and the state/tx/receipt roots cannot be, because block N is not sealed at that point — they are left carried/empty as before.

## Tests

- `TestNextBlockEnv_TimeAdvancesByBlockInterval` — asserts the admission env timestamp = parent + interval, and that the advanced time reaches the EVM block context (`TIMESTAMP` opcode).
- Extends `TestNextBlockEnv_DoesNotMutateReceiver` to cover `Time`.

`go build && go vet && go test ./miner/` green.
