### PR TITLE
core/types: use canonical blockAccessListHash JSON key for BAL hash

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -102,7 +102,7 @@ type Header struct {
 	RequestsHash *common.Hash `json:"requestsHash" rlp:"optional"`
 
 	// BlockAccessListHash was added by EIP-7928 and is ignored in legacy headers.
-	BlockAccessListHash *common.Hash `json:"balHash" rlp:"optional"`
+	BlockAccessListHash *common.Hash `json:"blockAccessListHash" rlp:"optional"`
 
 	// SlotNumber was added by EIP-7843 and is ignored in legacy headers.
 	SlotNumber *uint64 `json:"slotNumber" rlp:"optional"`

--- a/core/types/block_bal_json_test.go
+++ b/core/types/block_bal_json_test.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TestHeaderBlockAccessListHashJSONKey guards the JSON key of the EIP-7928
+// block-access-list hash header field. go-ethereum serializes it as
+// "blockAccessListHash"; a divergent key (e.g. "balHash") would make a node
+// silently drop the field when unmarshaling an upstream header and compute a
+// mismatching block hash.
+func TestHeaderBlockAccessListHashJSONKey(t *testing.T) {
+	bal := common.HexToHash("0xabc0000000000000000000000000000000000000000000000000000000000123")
+	h := &Header{
+		Number:              big.NewInt(1),
+		Difficulty:          big.NewInt(0),
+		BaseFee:             big.NewInt(7),
+		BlockAccessListHash: &bal,
+	}
+
+	enc, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	if !strings.Contains(string(enc), `"blockAccessListHash"`) {
+		t.Fatalf("expected canonical key blockAccessListHash, got: %s", enc)
+	}
+	if strings.Contains(string(enc), `"balHash"`) {
+		t.Fatalf("stale balHash key still present: %s", enc)
+	}
+
+	var got Header
+	if err := json.Unmarshal(enc, &got); err != nil {
+		t.Fatalf("unmarshal header: %v", err)
+	}
+	if got.BlockAccessListHash == nil || *got.BlockAccessListHash != bal {
+		t.Fatalf("BlockAccessListHash not round-tripped: got %v want %v", got.BlockAccessListHash, bal)
+	}
+}

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -37,7 +37,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
-		BlockAccessListHash *common.Hash    `json:"balHash" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
 		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 		Hash                common.Hash     `json:"hash"`
 	}
@@ -93,7 +93,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		ExcessBlobGas       *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
 		ParentBeaconRoot    *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 		RequestsHash        *common.Hash    `json:"requestsHash" rlp:"optional"`
-		BlockAccessListHash *common.Hash    `json:"balHash" rlp:"optional"`
+		BlockAccessListHash *common.Hash    `json:"blockAccessListHash" rlp:"optional"`
 		SlotNumber          *hexutil.Uint64 `json:"slotNumber" rlp:"optional"`
 	}
 	var dec Header


### PR DESCRIPTION
The EIP-7928 block-access-list hash header field was tagged json:"balHash", while go-ethereum serializes it as "blockAccessListHash". A node unmarshaling a header from an upstream geth (e.g. over eth_getBlockByNumber) therefore dropped the field, leaving it nil and computing a mismatching block hash.

The json tag does not affect RLP encoding or the block hash, so this only realigns the JSON-RPC key with go-ethereum; consensus is unchanged.